### PR TITLE
Fix for , in Window title

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -21,7 +21,7 @@ if (isAlreadyRunning) {
 }
 
 function updateBadge(title) {
-  const unreadCount = (/^.+\s\((\d+)\)/).exec(title)
+  const unreadCount = (/^.+\s\((\d+[,]?\d+)\)/).exec(title)
 
   app.dock.setBadge(unreadCount ? unreadCount[1] : '')
 }


### PR DESCRIPTION
If you have over 999 unread email you get a , in your unread count. ie 1,001

Updated regex to match.

Not sure if you get more commas the more unread you have.