### PR TITLE
add mailto support

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint src",
     "test": "npm run lint",
     "start": "electron .",
-    "build:osx": "electron-packager . --out=build --overwrite --platform=darwin --arch=x64 --icon=src/assets/icons/icon.icns --app-version=$npm_package_version",
+    "build:osx": "electron-packager . --protocol-name=\"Email Address URL\" --protocol=\"mailto\" --out=build --overwrite --platform=darwin --arch=x64 --icon=src/assets/icons/icon.icns --app-version=$npm_package_version",
     "build": "npm run clean && npm run build:osx"
   },
   "repository": {

--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@ import { app, shell, BrowserWindow, Menu } from 'electron'
 import menu from './menu'
 
 let mainWindow
+let replyToWindow
 let isQuitting = false
 
 const isAlreadyRunning = app.makeSingleInstance(() => {
@@ -46,6 +47,16 @@ function createWindow() {
   mainWindow.on('page-title-updated', (e, title) => updateBadge(title))
 }
 
+function createMailTo(url) {
+
+  replyToWindow = new BrowserWindow({
+    parent: mainWindow
+  })
+
+  replyToWindow.loadURL('https://mail.google.com/mail/?extsrc=mailto&url='+url)
+
+}
+
 app.on('ready', () => {
   createWindow()
   Menu.setApplicationMenu(menu)
@@ -65,6 +76,11 @@ app.on('ready', () => {
       shell.openExternal(url)
     }
   })
+})
+
+app.on('open-url', (event, url) => {
+  event.preventDefault()
+  createMailTo(url)
 })
 
 app.on('activate', () => {

--- a/src/app.js
+++ b/src/app.js
@@ -48,13 +48,11 @@ function createWindow() {
 }
 
 function createMailTo(url) {
-
   replyToWindow = new BrowserWindow({
     parent: mainWindow
   })
 
-  replyToWindow.loadURL('https://mail.google.com/mail/?extsrc=mailto&url='+url)
-
+  replyToWindow.loadURL(`https://mail.google.com/mail/?extsrc=mailto&url=${url}`)
 }
 
 app.on('ready', () => {

--- a/src/menu.js
+++ b/src/menu.js
@@ -39,6 +39,23 @@ const darwinMenu = [
     ]
   },
   {
+    label: 'Settings',
+    submenu: [
+      {
+        label: 'Enable MailTo: Support',
+        click() {
+          app.setAsDefaultProtocolClient('mailto')
+        }
+      },
+      {
+        label: 'Diable MailTo: Support',
+        click() {
+          app.removeAsDefaultProtocolClient('mailto')
+        }
+      }
+    ]
+  },
+  {
     label: 'Edit',
     submenu: [
       {

--- a/src/menu.js
+++ b/src/menu.js
@@ -3,6 +3,17 @@ import { app, shell, Menu } from 'electron'
 /* eslint-enable import/no-unresolved */
 
 const APP_NAME = app.getName()
+let mailtoStatus = app.isDefaultProtocolClient('mailto')
+
+function toggleMailto() {
+  if (app.isDefaultProtocolClient('mailto')) {
+    app.removeAsDefaultProtocolClient('mailto')
+    mailtoStatus = false
+  } else {
+    app.setAsDefaultProtocolClient('mailto')
+    mailtoStatus = true
+  }
+}
 
 const darwinMenu = [
   {
@@ -42,15 +53,11 @@ const darwinMenu = [
     label: 'Settings',
     submenu: [
       {
-        label: 'Enable MailTo: Support',
+        label: 'Default MailTo: Provider',
+        type: 'checkbox',
+        checked: mailtoStatus,
         click() {
-          app.setAsDefaultProtocolClient('mailto')
-        }
-      },
-      {
-        label: 'Diable MailTo: Support',
-        click() {
-          app.removeAsDefaultProtocolClient('mailto')
+          toggleMailto()
         }
       }
     ]


### PR DESCRIPTION
Add mailto support to the app.

I've added a new menu to the app called settings. Ideally it would only need one button and track if MailTo support has been enabled already yet.

Would you want that change for the button or are you happy as is?

Edit: Made the above menu change.