### PR TITLE
Fixes #2. Disabled nodeIntegration to fix jQuery

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -31,7 +31,10 @@ function createWindow() {
     title: app.getName(),
     width: 1280,
     height: 960,
-    titleBarStyle: 'hidden-inset'
+    titleBarStyle: 'hidden-inset',
+    webPreferences: {
+      nodeIntegration: false
+    }
   })
 
   mainWindow.loadURL('https://mail.google.com')


### PR DESCRIPTION
Often ueed by thirdparty IDPs / SAML auth services.