### PR TITLE
Fixed regular expression for single-digit unread counts

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -20,7 +20,7 @@ if (isAlreadyRunning) {
 }
 
 function updateBadge(title) {
-  const unreadCount = /^.+\s\((\d+[,]?\d+)\)/.exec(title)
+  const unreadCount = /^.+\s\((\d+[,]?\d*)\)/.exec(title)
 
   app.dock.setBadge(unreadCount ? unreadCount[1] : '')
 }


### PR DESCRIPTION
Fixes #10 

```
  (\d+[,]?\d+)
```
This pattern will fail for any inbox count with single digits, because it will be looking for two different instances of (1 or more) digits.  There are a few potential fixes for this, but I don't know which is the most correct.  I went with the simple case of making the second pattern be (0 or more) digits.  Some alternatives
```
([\d,]+)
```
This would match any combination of numbers and commas.
```
(\d+(?:,\d+)*)
```
I think that would match any list of comma-separated numbers.