### PR TITLE
Fix unread count

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,12 @@
 const path = require('path')
-const { app, shell, BrowserWindow, Menu, Tray } = require('electron')
+const {
+  app,
+  ipcMain: ipc,
+  shell,
+  BrowserWindow,
+  Menu,
+  Tray
+} = require('electron')
 const electronDebug = require('electron-debug')
 const { autoUpdater } = require('electron-updater')
 const { is } = require('electron-util')
@@ -42,7 +49,8 @@ function createWindow() {
     title: app.getName(),
     webPreferences: {
       nodeIntegration: false,
-      nativeWindowOpen: true
+      nativeWindowOpen: true,
+      preload: path.join(__dirname, 'preload.js')
     }
   })
 
@@ -58,12 +66,9 @@ function createWindow() {
     }
   })
 
-  mainWindow.on('page-title-updated', (e, title) => {
-    let unreadCount = /^.+\s\((\d+[,]?\d*)\)/.exec(title)
-    unreadCount = unreadCount && unreadCount[1]
-
+  ipc.on('unread-count', (_, unreadCount) => {
     if (is.macos) {
-      app.dock.setBadge(unreadCount || '')
+      app.dock.setBadge(unreadCount ? unreadCount.toString() : '')
     }
 
     if ((is.linux || is.windows) && tray) {

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,0 +1,39 @@
+/* eslint-env browser */
+
+const { ipcRenderer: ipc } = require('electron')
+
+const INTERVAL = 1000
+let count
+
+function getUnreadCount() {
+  // Find the number next to the inbox label
+  const label = document
+    .querySelector('div[role=navigation] [href*="#inbox"]')
+    .parentElement.parentElement.querySelector('.bsU')
+
+  // Return the unread count (0 by default)
+  return label ? Number(label.innerText.match(/\d/)) : 0
+}
+
+function updateUnreadCount() {
+  const newCount = getUnreadCount()
+
+  // Only fire the event when necessary
+  if (count !== newCount) {
+    ipc.send('unread-count', newCount)
+    count = newCount
+  }
+}
+
+window.addEventListener('load', () => {
+  // Set the initial unread count
+  updateUnreadCount()
+
+  // Listen to changes to the document title
+  const observer = new MutationObserver(updateUnreadCount)
+  observer.observe(document.querySelector('title'), { childList: true })
+
+  // Check the unread count on an interval timer for instances where
+  //   the title doesn't change
+  setInterval(updateUnreadCount, INTERVAL)
+})


### PR DESCRIPTION
Currently, the unread count changes based on which label you are in and if you have an email open, the unread count will never change since the title doesn't reflect the unread count.  This aims to solve this problem using the following process.

1. Add a preload script to the main window so we can execute JS code in Gmail.
1. When changes occur, grab the unread count from the inbox label on the left navigation bar

Changes to the unread count are tracked using one of two ways.

1. A MutationObserver that observes the title.  Even though the title does not always work for getting the unread count, it is a good event to listen to for checking the unread count.
1. An interval of 1 second (configurable through the `INTERVAL` const in preload.js) will check the unread count every second.  I tried adding a MutationObserver to the unread count in the sidebar, but it would only work if I went all the way up to the navigation element and observed all subtree changes which was much more intense than a simple 1 second interval.