### PR TITLE
Default window size

### DIFF
--- a/src/menu.js
+++ b/src/menu.js
@@ -1,4 +1,6 @@
 const { app, shell, Menu } = require('electron')
+const appConfig = require('electron-settings')
+const { is } = require('electron-util')
 
 const APP_NAME = app.getName()
 let mailtoStatus = app.isDefaultProtocolClient('mailto')
@@ -135,5 +137,24 @@ const darwinMenu = [
     ]
   }
 ]
+
+// Add the develop menu when running in the development environment
+if (is.development) {
+  darwinMenu.splice(-1, 0, {
+    label: 'Develop',
+    submenu: [
+      {
+        label: 'Clear cache and restart',
+        click() {
+          // Clear app config
+          appConfig.deleteAll()
+          // Restart without firing quitting events
+          app.relaunch()
+          app.exit(0)
+        }
+      }
+    ]
+  })
+}
 
 module.exports = Menu.buildFromTemplate(darwinMenu)

--- a/src/state/window.js
+++ b/src/state/window.js
@@ -1,10 +1,5 @@
 const appConfig = require('electron-settings')
 
-const defaultBounds = {
-  width: 1280,
-  height: 800
-}
-
 class WindowState {
   constructor(stateName, window) {
     this.stateName = `state.window.${stateName}`
@@ -14,11 +9,7 @@ class WindowState {
     //   otherwise use defaults
     this.state = appConfig.has(this.stateName)
       ? appConfig.get(this.stateName)
-      : {
-          ...defaultBounds,
-          x: window.getBounds().x,
-          y: window.getBounds().y
-        }
+      : { isMaximized: true }
 
     return this
   }


### PR DESCRIPTION
Fixes #31 

I added a Develop menu that currently only contains one item labeled "Clear cache and restart".  Clicking that item will clear the app state and restart the application without triggering any before-quit type events.  This allows us to quite the application without saving the current size to simulate how the app works if it was the first time starting it.