### PR TITLE
Only enable debug features when developer mode is enabled

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -7,22 +7,14 @@ const {
   Menu,
   Tray
 } = require('electron')
-const electronDebug = require('electron-debug')
-const appConfig = require('electron-settings')
 const { autoUpdater } = require('electron-updater')
 const { is } = require('electron-util')
 
+// Initialize the debug mode handler when starting the app
+require('./debug').init()
+
 const menu = require('./menu')
 const WindowState = require('./state/window')
-
-// Debug mode should only be enabled for development mode
-//   or when a user chooses developer mode
-if (is.development || appConfig.get('developer-mode')) {
-  electronDebug({
-    enabled: true,
-    showDevTools: false
-  })
-}
 
 if (!is.development) {
   autoUpdater.checkForUpdatesAndNotify()

--- a/src/app.js
+++ b/src/app.js
@@ -8,16 +8,21 @@ const {
   Tray
 } = require('electron')
 const electronDebug = require('electron-debug')
+const appConfig = require('electron-settings')
 const { autoUpdater } = require('electron-updater')
 const { is } = require('electron-util')
 
 const menu = require('./menu')
 const WindowState = require('./state/window')
 
-electronDebug({
-  enabled: true,
-  showDevTools: false
-})
+// Debug mode should only be enabled for development mode
+//   or when a user chooses developer mode
+if (is.development || appConfig.get('developer-mode')) {
+  electronDebug({
+    enabled: true,
+    showDevTools: false
+  })
+}
 
 if (!is.development) {
   autoUpdater.checkForUpdatesAndNotify()

--- a/src/debug.js
+++ b/src/debug.js
@@ -1,0 +1,47 @@
+const { app, dialog } = require('electron')
+const { is } = require('electron-util')
+const appConfig = require('electron-settings')
+const electronDebug = require('electron-debug')
+
+const CONFIG_KEY = 'debug-mode'
+const OPTIONS = {
+  showDevTools: false
+}
+
+function showRestartDialog(enabled) {
+  const state = enabled ? 'enable' : 'disable'
+
+  dialog.showMessageBox(
+    {
+      type: 'info',
+      buttons: ['Restart', 'Cancel'],
+      message: 'Restart required',
+      detail: `To ${state} debug mode, please restart Gmail Desktop`
+    },
+    response => {
+      // If restart was clicked (index of 0), restart the app
+      if (response === 0) {
+        app.relaunch()
+        app.quit()
+      }
+    }
+  )
+}
+
+function init() {
+  let enabled = appConfig.get(CONFIG_KEY)
+
+  // If the environment is development and debug-mode hasn't been set,
+  //   default debug mode to enabled
+  if (is.development && enabled === null) {
+    enabled = true
+  }
+
+  electronDebug({ ...OPTIONS, enabled })
+}
+
+module.exports = {
+  CONFIG_KEY,
+  init,
+  showRestartDialog
+}

--- a/src/menu.js
+++ b/src/menu.js
@@ -15,6 +15,11 @@ function toggleMailto() {
   }
 }
 
+const developerMode = appConfig.get('developer-mode')
+function toggleDeveloperMode() {
+  appConfig.set('developer-mode', !developerMode)
+}
+
 const darwinMenu = [
   {
     label: APP_NAME,
@@ -58,6 +63,14 @@ const darwinMenu = [
         checked: mailtoStatus,
         click() {
           toggleMailto()
+        }
+      },
+      {
+        label: 'Developer Mode',
+        type: 'checkbox',
+        checked: developerMode,
+        click() {
+          toggleDeveloperMode()
         }
       }
     ]
@@ -139,7 +152,8 @@ const darwinMenu = [
 ]
 
 // Add the develop menu when running in the development environment
-if (is.development) {
+//   or if developer mode is enabled
+if (is.development || developerMode) {
   darwinMenu.splice(-1, 0, {
     label: 'Develop',
     submenu: [

--- a/src/menu.js
+++ b/src/menu.js
@@ -2,6 +2,11 @@ const { app, shell, Menu } = require('electron')
 const appConfig = require('electron-settings')
 const { is } = require('electron-util')
 
+const {
+  CONFIG_KEY: DEBUG_MODE_CONFIG_KEY,
+  showRestartDialog
+} = require('./debug')
+
 const APP_NAME = app.getName()
 let mailtoStatus = app.isDefaultProtocolClient('mailto')
 
@@ -15,9 +20,12 @@ function toggleMailto() {
   }
 }
 
-const developerMode = appConfig.get('developer-mode')
-function toggleDeveloperMode() {
-  appConfig.set('developer-mode', !developerMode)
+const debugMode = appConfig.get(DEBUG_MODE_CONFIG_KEY)
+function toggleDebugMode() {
+  const enabled = !debugMode
+
+  appConfig.set(DEBUG_MODE_CONFIG_KEY, enabled)
+  showRestartDialog(enabled)
 }
 
 const darwinMenu = [
@@ -66,11 +74,11 @@ const darwinMenu = [
         }
       },
       {
-        label: 'Developer Mode',
+        label: 'Debug Mode',
         type: 'checkbox',
-        checked: developerMode,
+        checked: debugMode,
         click() {
-          toggleDeveloperMode()
+          toggleDebugMode()
         }
       }
     ]
@@ -152,8 +160,7 @@ const darwinMenu = [
 ]
 
 // Add the develop menu when running in the development environment
-//   or if developer mode is enabled
-if (is.development || developerMode) {
+if (is.development) {
   darwinMenu.splice(-1, 0, {
     label: 'Develop',
     submenu: [


### PR DESCRIPTION
This is not a finished PR as I still would like to explore reloading the menu when the settings change as well as enabling or disabling `electronDebug`.

Fixes #33