### PR TITLE
Fix window state not saving

### DIFF
--- a/src/state/window.ts
+++ b/src/state/window.ts
@@ -58,7 +58,7 @@ export default class WindowState {
     const isFullScreen = this._window.isFullScreen()
 
     this._state = { isFullScreen, isMaximized }
-    if (isMaximized || isFullScreen) {
+    if (!(isMaximized || isFullScreen)) {
       this._state.bounds = this._window.getBounds()
     }
 


### PR DESCRIPTION
I accidentally reversed the conditional when we updated to TypeScript.  Fixes #52 