### PR TITLE
Specify artifact name to fix auto updater issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     }
   },
   "build": {
+    "artifactName": "${name}-${version}-${os}.${ext}",
     "files": [
       "**/*"
     ],


### PR DESCRIPTION
I think this should fix the update problems we are having in #47.  I haven't tested the output for Windows, but Mac and Linux appear to build the proper file names.  @timche Could you test this for Windows?