### PR TITLE
disable windows code signature check on update

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,9 @@
         "deb"
       ],
       "category": "Network;Office"
+    },
+    "win": {
+      "verifyUpdateCodeSignature": false
     }
   }
 }


### PR DESCRIPTION
Same issue on Windows as explained here: https://github.com/sindresorhus/caprine/issues/752#issuecomment-458648468