### PR TITLE
fix account switching

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,14 @@
+import electronUtils from 'electron-util'
+
+// URL: `mail.google.com/mail/u/<local_account_id>`
+export function getUrlAccountId(url: string): null | string {
+  const accountIdRegExp = /mail\/u\/(\d+)\//
+  const res = accountIdRegExp.exec(url)
+  return res && res[1]
+}
+
+export const platform = electronUtils.platform({
+  macos: 'macos',
+  linux: 'linux',
+  windows: 'windows'
+})


### PR DESCRIPTION
Currently when adding a new or switching to another account their links will be opened in a new window instead in the main window.