### PR TITLE
fix search bar styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -153,7 +153,7 @@ body.xE .G-atb {
 /* Footer text */
 .minimal-mode .aeG,
 /* Support question mark */
-.minimal-mode .gb_fe,
+.minimal-mode .gb_ge,
 /* Side panel */
 .minimal-mode .bAw,
 /* Keyboard button */

--- a/css/style.css
+++ b/css/style.css
@@ -67,23 +67,27 @@ body.xE .G-atb {
   min-width: 192px !important;
 }
 
-.gb_wd.gb_Fd .gb_td .gb_ne {
-  margin-top: 9px;
+.gb_td.gb_la {
+  margin-top: -3px !important;
 }
 
-.gb_ne,
-.gb_2e,
-.gb_Ie {
+.gb_wd.gb_Fd .gb_td .gb_ne {
+  margin-top: 9px !important;
+}
+
+.gb_td,
+.gb_3e,
+.gb_Je {
   height: 28px !important;
 }
 
-.gb_ne button svg,
-.gb_ne button img {
+.gb_td button svg,
+.gb_td button img {
   padding: 2px !important;
   margin: 0 !important;
 }
 
-.gb_Ie {
+.gb_Je {
   font: normal 14px Roboto, sans-serif !important;
 }
 


### PR DESCRIPTION
Gmail shipped an update which changed the search bar and its classes.

Before:
![Screenshot 2019-05-01 at 12 41 05](https://user-images.githubusercontent.com/8075074/57016351-944f9c80-6c11-11e9-8984-a295dca7315e.png)

After:
![Screenshot 2019-05-01 at 13 02 48](https://user-images.githubusercontent.com/8075074/57016365-a2052200-6c11-11e9-804b-1d6bd49e712f.png)
