### PR TITLE
More custom style fixes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -54,6 +54,7 @@ header > div:nth-child(2) {
 }
 
 /* Header items height (hamburger menu, search box, profile image) */
+/* The :not(:nth-child(5)) selector prevents setting an explicit height for the account information popup */
 header > div:nth-child(2) > div:not(:nth-child(5)) {
   height: 28px;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -53,6 +53,12 @@ header > div:nth-child(2) {
   padding: 5px !important;
 }
 
+/* Decrease padding for message toolbar button strip in new window */
+body.xE .G-atb {
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
 /* Header items height (hamburger menu, search box, profile image) */
 header > div:nth-child(2) > div {
   height: 28px;

--- a/css/style.css
+++ b/css/style.css
@@ -54,7 +54,6 @@ header > div:nth-child(2) {
 }
 
 /* Header items height (hamburger menu, search box, profile image) */
-/* The not selector is to prevent the account switcher height from being affected */
 header > div:nth-child(2) > div:not(:nth-child(5)) {
   height: 28px;
 }
@@ -107,9 +106,49 @@ header > div:nth-child(2) > div:nth-child(5) {
   top: 48px;
 }
 
-/* Fix height of message toolbar button strip in new window */
-body.xE .G-atb {
-  padding: 6px 15px;
+/**
+ * ACCOUNT LINK FOR G SUITE ACCOUNTS
+ * ----------------------------------------
+ * Note: The [role='button'] selector on all of the following styles is necessary
+ * to ensure that these styles are only applied to G Suite account links and not
+ * normal account avatars.
+ */
+
+/* Account link container height */
+header > div:nth-child(2) > div:nth-child(3) > div > div:last-child[role='button'] {
+  max-height: 32px !important;
+}
+
+/* Remove padding and line height from account logo and avatar to fix vertical alignment */
+header > div:nth-child(2) > div:nth-child(3) > div > div:last-child[role='button'] > div {
+  line-height: unset !important;
+  padding-bottom: 0;
+  padding-top: 0;
+}
+
+/* Shrink account logo to fit properly in the container while maintaining the aspect ratio */
+header > div:nth-child(2) > div:nth-child(3) > div > div:last-child[role='button'] > div:first-child > img {
+  width: 73px !important;
+  max-height: 30px !important;
+}
+
+/* Account avatar link */
+header > div:nth-child(2) > div:nth-child(3) > div > div:last-child[role='button'] a {
+  height: 28px;
+  padding: 0 4px;
+}
+
+/* Account avatar background image size */
+header > div:nth-child(2) > div:nth-child(3) > div > div:last-child[role='button'] a > span {
+  background-size: 28px 28px;
+  box-shadow: none;
+  height: 28px;
+  width: 28px;
+}
+
+/* Account avatar background image origin */
+header > div:nth-child(2) > div:nth-child(3) > div > div:last-child[role='button'] a > span::before {
+  transform-origin: -4px -4px;
 }
 
 /**

--- a/css/style.css
+++ b/css/style.css
@@ -3,7 +3,13 @@
  * ----------------------------------------
  */
 
-header {
+header,
+/* Compose in new window */
+.Io,
+/* Message toolbar in new window */
+body.xE .G-atb,
+/* PDF viewer header */
+div[aria-label='Showing viewer.'] > div:nth-child(3) > div {
   -webkit-app-region: drag;
 }
 
@@ -19,7 +25,13 @@ header > div:nth-child(2) > div:nth-child(2) form,
 /* Support question mark */
 header > div:nth-child(2) > div:nth-child(2) > div:nth-child(3) a,
 /* User avatar */
-header > div:nth-child(2) > div:nth-child(3) a {
+header > div:nth-child(2) > div:nth-child(3) a,
+/* Minimize button in new compose window header */
+.Io > div:first-child,
+/* Message toolbar button strip in new window */
+body.xE .G-atb .G-tF,
+/* PDF viewer header elements (buttons, text, etc.) */
+div[aria-label='Showing viewer.'] > div:nth-child(3) > div > div {
   -webkit-app-region: no-drag;
 }
 
@@ -42,7 +54,8 @@ header > div:nth-child(2) {
 }
 
 /* Header items height (hamburger menu, search box, profile image) */
-header > div:nth-child(2) > div {
+/* The not selector is to prevent the account switcher height from being affected */
+header > div:nth-child(2) > div:not(:nth-child(5)) {
   height: 28px;
 }
 
@@ -85,7 +98,18 @@ header > div:nth-child(2) > div:nth-child(2) form > button > svg {
 
 /* Header search box input */
 header > div:nth-child(2) > div:nth-child(2) form input {
+  font-size: 14px;
   top: -9px !important;
+}
+
+/* Account information popup (when you click the user avatar) */
+header > div:nth-child(2) > div:nth-child(5) {
+  top: 48px;
+}
+
+/* Fix height of message toolbar button strip in new window */
+body.xE .G-atb {
+  padding: 6px 15px;
 }
 
 /**

--- a/css/style.css
+++ b/css/style.css
@@ -54,8 +54,7 @@ header > div:nth-child(2) {
 }
 
 /* Header items height (hamburger menu, search box, profile image) */
-/* The :not(:nth-child(5)) selector prevents setting an explicit height for the account information popup */
-header > div:nth-child(2) > div:not(:nth-child(5)) {
+header > div:nth-child(2) > div {
   height: 28px;
 }
 
@@ -104,6 +103,7 @@ header > div:nth-child(2) > div:nth-child(2) form input {
 
 /* Account information popup (when you click the user avatar) */
 header > div:nth-child(2) > div:nth-child(5) {
+  height: auto;
   top: 48px;
 }
 

--- a/css/style.macos.css
+++ b/css/style.macos.css
@@ -1,4 +1,20 @@
-/* Move hamburger menu over so it isn't under the traffic lights */
-header > div:nth-child(2) > div:first-child > div:first-child {
+/**
+ * TRAFFIC LIGHT POSITION
+ * ----------------------------------------
+ */
+
+/* Hamburger menu */
+header > div:nth-child(2) > div:first-child > div:first-child,
+/* "New Message" header in compose new message window */
+.Io > div:last-child,
+/* Message toolbar button strip in new window */
+body.xE .G-atb .G-tF,
+/* PDF viewer header back button */
+div[aria-label='Showing viewer.'] > div:nth-child(3) > div {
   margin-left: 75px;
+}
+
+/* Don't set explicit width for "New Message" header in compose new message window */
+.Io > div:last-child {
+  width: auto;
 }


### PR DESCRIPTION
Fixes a number of issues with the recent custom style changes.

- Adds selectors for dragging headers for new windows and pdf viewer
- Adds left padding for macos for new window and pdf viewer headers
- Fix height for G Suite account links (it is larger than the normal account avatar)