### PR TITLE
Add download notifications

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -12,19 +12,18 @@ import {
 import { autoUpdater } from 'electron-updater'
 import { is } from 'electron-util'
 import log from 'electron-log'
-import electronDl from 'electron-dl'
 import electronContextMenu from 'electron-context-menu'
 
 import config, { ConfigKey } from './config'
 import { init as initDebug } from './debug'
+import { init as initDownloads } from './downloads'
 import menu from './menu'
 import { init as initCustomStyles } from './custom-styles'
 import { platform, getUrlAccountId } from './helpers'
 
-// Initialize the debug mode handler when starting the app
 initDebug()
+initDownloads()
 
-electronDl({ showBadge: false })
 electronContextMenu({ showCopyImageAddress: true, showSaveImageAs: true })
 
 if (!is.development) {

--- a/src/downloads.ts
+++ b/src/downloads.ts
@@ -1,0 +1,41 @@
+import { Notification, shell, app } from 'electron'
+import * as path from 'path'
+import electronDl from 'electron-dl'
+
+type State = 'cancelled' | 'completed' | 'interrupted'
+
+const messages = {
+  cancelled: 'has been cancelled',
+  completed: 'has completed',
+  interrupted: 'has been interrupted'
+}
+
+function onDownloadComplete(filename: string, state: State): void {
+  const notification = new Notification({
+    actions: [
+      {
+        type: 'button',
+        text: 'Open'
+      }
+    ],
+    body: `Download of file ${filename} ${messages[state]}.`,
+    title: `Download ${state}`
+  })
+
+  notification.on('action', () => {
+    shell.openItem(path.join(app.getPath('downloads'), filename))
+  })
+
+  notification.show()
+}
+
+export function init(): void {
+  electronDl({
+    showBadge: false,
+    onStarted: item => {
+      item.on('done', (_, state) => {
+        onDownloadComplete(item.getFilename(), state)
+      })
+    }
+  })
+}


### PR DESCRIPTION
Since adding electron-dl it has been frustrating because there is no visual indicator that downloads are processing except for the progress bar in the dock.  This adds notifications when downloads are complete.  I added an action of "Open" to the download notification so users could open the item.