### PR TITLE
Align hamburger menu when app is in full screen on OSX

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -7,7 +7,7 @@
 /* Compose in new window */
 .compactHeader .Io,
 /* Message toolbar in new window */
-body.compactHeader.xE .G-atb,
+.compactHeader.xE .G-atb,
 /* PDF viewer header */
 .compactHeader div[aria-label='Showing viewer.'] > div:nth-child(3) > div {
   -webkit-app-region: drag;
@@ -31,7 +31,7 @@ body.compactHeader.xE .G-atb,
 /* Minimize button in new compose window header */
 .compactHeader .Io > div:first-child,
 /* Message toolbar button strip in new window */
-body.compactHeader.xE .G-atb .G-tF,
+.compactHeader.xE .G-atb .G-tF,
 /* PDF viewer header elements (buttons, text, etc.) */
 .compactHeader div[aria-label='Showing viewer.'] > div:nth-child(3) > div > div {
   -webkit-app-region: no-drag;
@@ -56,7 +56,7 @@ body.compactHeader.xE .G-atb .G-tF,
 }
 
 /* Decrease padding for message toolbar button strip in new window */
-body.compactHeader.xE .G-atb {
+.compactHeader.xE .G-atb {
   padding-top: 6px;
   padding-bottom: 6px;
 }

--- a/css/style.macos.css
+++ b/css/style.macos.css
@@ -4,17 +4,17 @@
  */
 
 /* Hamburger menu */
-.compactHeader header > div:nth-child(2) > div:first-child > div:first-child,
+.compactHeader:not(.full-screen) header > div:nth-child(2) > div:first-child > div:first-child,
 /* "New Message" header in compose new message window */
-.compactHeader .Io > div:last-child,
+.compactHeader:not(.full-screen) .Io > div:last-child,
 /* Message toolbar button strip in new window */
-body.compactHeader.xE .G-atb .G-tF,
+.compactHeader.xE:not(.full-screen) .G-atb .G-tF,
 /* PDF viewer header back button */
-.compactHeader div[aria-label='Showing viewer.'] > div:nth-child(3) > div {
+.compactHeader:not(.full-screen) div[aria-label='Showing viewer.'] > div:nth-child(3) > div {
   margin-left: 75px;
 }
 
 /* Don't set explicit width for "New Message" header in compose new message window */
-.compactHeader .Io > div:last-child {
+.compactHeader:not(.full-screen) .Io > div:last-child {
   width: auto;
 }

--- a/src/custom-styles.ts
+++ b/src/custom-styles.ts
@@ -2,7 +2,7 @@ import { app } from 'electron'
 import * as path from 'path'
 
 import config, { ConfigKey } from './config'
-import { sendChannelToMainWindow } from './utils'
+import { sendChannelToMainWindow, getMainWindow } from './utils'
 
 export const USER_CUSTOM_STYLE_PATH = path.join(
   app.getPath('userData'),
@@ -13,6 +13,18 @@ export function setCustomStyle(key: ConfigKey, enabled: boolean): void {
   sendChannelToMainWindow('set-custom-style', key, enabled)
 }
 
+function initFullScreenStyles(): void {
+  const mainWindow = getMainWindow()
+
+  mainWindow.on('enter-full-screen', () =>
+    sendChannelToMainWindow('set-full-screen', true)
+  )
+
+  mainWindow.on('leave-full-screen', () =>
+    sendChannelToMainWindow('set-full-screen', false)
+  )
+}
+
 export function init(): void {
   ;[
     ConfigKey.CompactHeader,
@@ -20,4 +32,6 @@ export function init(): void {
     ConfigKey.HideRightSidebar,
     ConfigKey.HideSupport
   ].forEach(key => setCustomStyle(key, config.get(key as string) as boolean))
+
+  initFullScreenStyles()
 }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -91,3 +91,8 @@ window.addEventListener('load', () => {
 ipc.on('set-custom-style', (_: Event, key: ConfigKey, enabled: boolean) => {
   document.body.classList[enabled ? 'add' : 'remove'](key)
 })
+
+// Toggle a full screen class when a message is received from the main process
+ipc.on('set-full-screen', (_: Event, enabled: boolean) => {
+  document.body.classList[enabled ? 'add' : 'remove']('full-screen')
+})


### PR DESCRIPTION
This adds a listener to the Electron full screen events to add a body class that will align the hamburger menu on OSX.

Fixes #87 