### PR TITLE
Update electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/semver": "^6.0.1",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
-    "electron": "3.0.4",
+    "electron": "^6.0.9",
     "electron-builder": "^21.2.0",
     "eslint-config-prettier": "^6.1.0",
     "eslint-config-xo-typescript": "^0.17.0",
@@ -118,10 +118,10 @@
     },
     "win": {
       "verifyUpdateCodeSignature": false,
-       "target": [
-         "nsis",
-         "zip"
-       ]
+      "target": [
+        "nsis",
+        "zip"
+      ]
     }
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -197,7 +197,8 @@ app.on('ready', () => {
       const targetAccountId = getUrlAccountId(url)
 
       if (targetAccountId !== currentAccountId) {
-        return mainWindow.loadURL(url)
+        mainWindow.loadURL(url)
+        return
       }
 
       // Center the new window on the screen

--- a/src/app.ts
+++ b/src/app.ts
@@ -204,6 +204,7 @@ app.on('ready', () => {
       // Center the new window on the screen
       event.newGuest = new BrowserWindow({
         ...options,
+        titleBarStyle: 'default',
         x: null,
         y: null
       })

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -82,7 +82,7 @@ const applicationMenu: MenuItemConstructorOptions[] = [
       {
         label: 'Hide Others',
         accelerator: 'Cmd+Shift+H',
-        role: 'hideothers'
+        role: 'hideOthers'
       },
       {
         label: 'Show All',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,22 +11,22 @@ export function sendChannelToMainWindow(
   getMainWindow().webContents.send(channel, ...args)
 }
 
-export function showRestartDialog(enabled: boolean, name: string): void {
+export async function showRestartDialog(
+  enabled: boolean,
+  name: string
+): Promise<void> {
   const state = enabled ? 'enable' : 'disable'
 
-  dialog.showMessageBox(
-    {
-      type: 'info',
-      buttons: ['Restart', 'Cancel'],
-      message: 'Restart required',
-      detail: `To ${state} ${name}, please restart ${app.getName()}`
-    },
-    response => {
-      // If restart was clicked (index of 0), restart the app
-      if (response === 0) {
-        app.relaunch()
-        app.quit()
-      }
-    }
-  )
+  const { response } = await dialog.showMessageBox({
+    type: 'info',
+    buttons: ['Restart', 'Cancel'],
+    message: 'Restart required',
+    detail: `To ${state} ${name}, please restart ${app.getName()}`
+  })
+
+  // If restart was clicked (index of 0), restart the app
+  if (response === 0) {
+    app.relaunch()
+    app.quit()
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -229,10 +229,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.2.tgz#c4e63af5e8823ce9cc3f0b34f7b998c2171f0c44"
   integrity sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==
 
-"@types/node@^8.0.24":
-  version "8.10.52"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.52.tgz#ef0ca1809994e20186090408b8cb7f2a6877d5f9"
-  integrity sha512-2RbW7WXeLex6RI+kQSxq6Ym0GiVcODeQ4Km7MnnTX5BHdOGQnqVa+s6AUmAW+OFYAJ8wv9QxvNZXm7/kBdGTVw==
+"@types/node@^10.12.18":
+  version "10.14.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.18.tgz#b7d45fc950e6ffd7edc685e890d13aa7b8535dce"
+  integrity sha512-ryO3Q3++yZC/+b8j8BdKd/dn9JlzlHBPdm80656xwYUdmPkpTGTjkAdt6BByiNupGPE8w0FhBgvYy/fX9hRNGQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -1532,12 +1532,12 @@ electron-util@^0.12.1:
     electron-is-dev "^1.1.0"
     new-github-issue-url "^0.2.1"
 
-electron@3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-3.0.4.tgz#9b45a0171ac424d4c134721c9cf2a891b99e80f2"
-  integrity sha512-GuZ4xCmV8wNNfkUAOdmOmgkYYaTQj5LATzc2i/b3MGhoXghnjECCgxo5yW+G2BeKM+R30cg69KA03tRzmIFxxQ==
+electron@^6.0.9:
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-6.0.9.tgz#fea15e9fec329248db500b33ba6544a26fe025a3"
+  integrity sha512-lFpSmDNyjpvJFwEnK897Soone3DV7D3ASFUb315H2VTVZSbKib9Kbrsovxf4c+e1q5hTdaONsGIm3Lb4CXIW1g==
   dependencies:
-    "@types/node" "^8.0.24"
+    "@types/node" "^10.12.18"
     electron-download "^4.1.0"
     extract-zip "^1.0.3"
 


### PR DESCRIPTION
The reason we wanted to stay with electron version 3 was due to the preload script not working properly.  Now that we are 3 major versions behind, I think it is time to update to electron 6 and let the new window styles go until we can get them to work with electron 6.

Fixes #148 