### PR TITLE
Support starting app minimized to tray

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -30,12 +30,15 @@ initAutoUpdates()
 
 electronContextMenu({ showCopyImageAddress: true, showSaveImageAs: true })
 
+const shouldStartMinimized = app.commandLine.hasSwitch('start-minimized')
+
 app.setAppUserModelId('io.cheung.gmail-desktop')
 
 let mainWindow: BrowserWindow
 let replyToWindow: BrowserWindow
 let isQuitting = false
 let tray: Tray
+let trayContextMenu: Menu
 
 if (!app.requestSingleInstanceLock()) {
   app.quit()
@@ -67,7 +70,8 @@ function createWindow(): void {
       nodeIntegration: false,
       nativeWindowOpen: true,
       preload: path.join(__dirname, 'preload')
-    }
+    },
+    show: !shouldStartMinimized
   })
 
   if (lastWindowState.fullscreen && !mainWindow.isFullScreen()) {
@@ -92,6 +96,16 @@ function createWindow(): void {
       mainWindow.hide()
     }
   })
+
+  mainWindow.on('hide', () => toggleAppVisiblityTrayItem(false))
+
+  mainWindow.on('show', () => toggleAppVisiblityTrayItem(true))
+
+  function toggleAppVisiblityTrayItem(isMainWindowVisible: boolean) {
+    trayContextMenu.getMenuItemById('show-win').visible = !isMainWindowVisible
+    trayContextMenu.getMenuItemById('hide-win').visible = isMainWindowVisible
+    tray.setContextMenu(trayContextMenu)
+  }
 
   ipc.on('unread-count', (_: Event, unreadCount: number) => {
     if (is.macos) {
@@ -158,18 +172,28 @@ app.on('ready', () => {
 
     if (is.linux) {
       contextMenuTemplate.unshift({
-        click: () => {
-          mainWindow.show()
+          click: () => {
+            mainWindow.show()
+          },
+          label: 'Show',
+          visible: shouldStartMinimized,
+          id: 'show-win'
         },
-        label: 'Show'
-      })
+        {
+          label: 'Hide',
+          visible: !shouldStartMinimized,
+          click: () => {
+            mainWindow.hide()
+          },
+          id: 'hide-win'
+        })
     }
 
-    const contextMenu = Menu.buildFromTemplate(contextMenuTemplate)
+    trayContextMenu = Menu.buildFromTemplate(contextMenuTemplate)
 
     tray = new Tray(iconPath)
     tray.setToolTip(appName)
-    tray.setContextMenu(contextMenu)
+    tray.setContextMenu(trayContextMenu)
     tray.on('click', () => {
       mainWindow.show()
     })
@@ -178,7 +202,9 @@ app.on('ready', () => {
   const { webContents } = mainWindow
 
   webContents.on('dom-ready', () => {
-    mainWindow.show()
+    if (!shouldStartMinimized) {
+      mainWindow.show()
+    }
   })
 
   // eslint-disable-next-line max-params

--- a/src/app.ts
+++ b/src/app.ts
@@ -30,7 +30,9 @@ initAutoUpdates()
 
 electronContextMenu({ showCopyImageAddress: true, showSaveImageAs: true })
 
-const shouldStartMinimized = app.commandLine.hasSwitch('start-minimized')
+const shouldStartMinimized =
+  app.commandLine.hasSwitch('start-minimized') ||
+  config.get(ConfigKey.LaunchMinimized)
 
 app.setAppUserModelId('io.cheung.gmail-desktop')
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -101,7 +101,7 @@ function createWindow(): void {
 
   mainWindow.on('show', () => toggleAppVisiblityTrayItem(true))
 
-  function toggleAppVisiblityTrayItem(isMainWindowVisible: boolean) {
+  function toggleAppVisiblityTrayItem(isMainWindowVisible: boolean): void {
     trayContextMenu.getMenuItemById('show-win').visible = !isMainWindowVisible
     trayContextMenu.getMenuItemById('hide-win').visible = isMainWindowVisible
     tray.setContextMenu(trayContextMenu)
@@ -171,7 +171,8 @@ app.on('ready', () => {
     ]
 
     if (is.linux) {
-      contextMenuTemplate.unshift({
+      contextMenuTemplate.unshift(
+        {
           click: () => {
             mainWindow.show()
           },
@@ -186,7 +187,8 @@ app.on('ready', () => {
             mainWindow.hide()
           },
           id: 'hide-win'
-        })
+        }
+      )
     }
 
     trayContextMenu = Menu.buildFromTemplate(contextMenuTemplate)

--- a/src/app.ts
+++ b/src/app.ts
@@ -31,7 +31,7 @@ initAutoUpdates()
 electronContextMenu({ showCopyImageAddress: true, showSaveImageAs: true })
 
 const shouldStartMinimized =
-  app.commandLine.hasSwitch('start-minimized') ||
+  app.commandLine.hasSwitch('launch-minimized') ||
   config.get(ConfigKey.LaunchMinimized)
 
 app.setAppUserModelId('io.cheung.gmail-desktop')

--- a/src/app.ts
+++ b/src/app.ts
@@ -104,6 +104,10 @@ function createWindow(): void {
   mainWindow.on('show', () => toggleAppVisiblityTrayItem(true))
 
   function toggleAppVisiblityTrayItem(isMainWindowVisible: boolean): void {
+    if (is.macos) {
+      return
+    }
+
     trayContextMenu.getMenuItemById('show-win').visible = !isMainWindowVisible
     trayContextMenu.getMenuItemById('hide-win').visible = isMainWindowVisible
     tray.setContextMenu(trayContextMenu)

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,7 +20,8 @@ export enum ConfigKey {
   HideFooter = 'hideFooter',
   HideRightSidebar = 'hideRightSidebar',
   HideSupport = 'hideSupport',
-  LastWindowState = 'lastWindowState'
+  LastWindowState = 'lastWindowState',
+  LaunchMinimized = 'launchMinimized'
 }
 
 type TypedStore = {
@@ -31,6 +32,7 @@ type TypedStore = {
   [ConfigKey.HideRightSidebar]: boolean
   [ConfigKey.HideSupport]: boolean
   [ConfigKey.DebugMode]: boolean
+  [ConfigKey.LaunchMinimized]: boolean
 }
 
 const defaults = {
@@ -49,7 +51,8 @@ const defaults = {
   [ConfigKey.HideFooter]: true,
   [ConfigKey.HideRightSidebar]: true,
   [ConfigKey.HideSupport]: true,
-  [ConfigKey.DebugMode]: false
+  [ConfigKey.DebugMode]: false,
+  [ConfigKey.LaunchMinimized]: false
 }
 
 const config = new Store<TypedStore>({

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -130,6 +130,14 @@ const applicationMenu: MenuItemConstructorOptions[] = [
         }
       },
       {
+        label: 'Launch minimized',
+        type: 'checkbox',
+        checked: config.get(ConfigKey.LaunchMinimized),
+        click({ checked }: { checked: boolean }) {
+          config.set(ConfigKey.LaunchMinimized, checked)
+        }
+      },
+      {
         label: 'Default Mailto Client',
         type: 'checkbox',
         checked: app.isDefaultProtocolClient('mailto'),


### PR DESCRIPTION
1. Uses the new `--start-minimized`  [command line switch](https://electronjs.org/docs/api/app#appcommandlinehasswitchswitch) to decide if the app should start minimized.
2. Bug fix: The tray context menu item "Show" wasn't being updated. Meaning, when the app is open, tray should say "Hide" and vice-versa. This has now been fixed.

Verified these changes on Linux and Windows, someone else has to dirty test it on macOS.

Thoughts?