### PR TITLE
fix issue #88 by adding option to hide Menu bar

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -21,6 +21,7 @@ import { init as initDebug } from './debug'
 import { init as initDownloads } from './downloads'
 import { platform, getUrlAccountId } from './helpers'
 import menu from './menu'
+import { setAppMenuBarVisibility } from './utils'
 
 import electronContextMenu = require('electron-context-menu')
 
@@ -83,6 +84,8 @@ function createWindow(): void {
   if (lastWindowState.maximized && !mainWindow.isMaximized()) {
     mainWindow.maximize()
   }
+
+  setAppMenuBarVisibility()
 
   mainWindow.loadURL('https://mail.google.com')
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -85,7 +85,9 @@ function createWindow(): void {
     mainWindow.maximize()
   }
 
-  setAppMenuBarVisibility()
+  if (is.linux || is.windows) {
+    setAppMenuBarVisibility()
+  }
 
   mainWindow.loadURL('https://mail.google.com')
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,8 @@ export enum ConfigKey {
   HideRightSidebar = 'hideRightSidebar',
   HideSupport = 'hideSupport',
   LastWindowState = 'lastWindowState',
-  LaunchMinimized = 'launchMinimized'
+  LaunchMinimized = 'launchMinimized',
+  AutoHideMenuBar = 'autoHideMenuBar'
 }
 
 type TypedStore = {
@@ -33,6 +34,7 @@ type TypedStore = {
   [ConfigKey.HideSupport]: boolean
   [ConfigKey.DebugMode]: boolean
   [ConfigKey.LaunchMinimized]: boolean
+  [ConfigKey.AutoHideMenuBar]: boolean
 }
 
 const defaults = {
@@ -52,7 +54,8 @@ const defaults = {
   [ConfigKey.HideRightSidebar]: true,
   [ConfigKey.HideSupport]: true,
   [ConfigKey.DebugMode]: false,
-  [ConfigKey.LaunchMinimized]: false
+  [ConfigKey.LaunchMinimized]: false,
+  [ConfigKey.AutoHideMenuBar]: false
 }
 
 const config = new Store<TypedStore>({

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -63,7 +63,7 @@ const createAppearanceMenuItem = ({
     }
 
     if (setMenuBarVisibility) {
-      setAppMenuBarVisibility()
+      setAppMenuBarVisibility(true)
     }
   }
 })

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -14,6 +14,7 @@ interface AppearanceMenuItem {
   key: ConfigKey
   label: string
   restartDialogText?: string
+  setMenuBarVisibility?: boolean
 }
 
 const appearanceMenuItems: AppearanceMenuItem[] = [
@@ -21,6 +22,11 @@ const appearanceMenuItems: AppearanceMenuItem[] = [
     key: ConfigKey.CompactHeader,
     label: 'Compact Header',
     restartDialogText: 'compact header'
+  },
+  {
+    key: ConfigKey.AutoHideMenuBar,
+    label: 'Hide Menu bar',
+    setMenuBarVisibility: true
   },
   {
     key: ConfigKey.HideFooter,
@@ -39,7 +45,8 @@ const appearanceMenuItems: AppearanceMenuItem[] = [
 const createAppearanceMenuItem = ({
   key,
   label,
-  restartDialogText
+  restartDialogText,
+  setMenuBarVisibility
 }: AppearanceMenuItem): MenuItemConstructorOptions => ({
   label,
   type: 'checkbox',
@@ -53,6 +60,10 @@ const createAppearanceMenuItem = ({
       showRestartDialog(checked, restartDialogText)
     } else {
       setCustomStyle(key, checked)
+    }
+
+    if (setMenuBarVisibility) {
+      setAppMenuBarVisibility()
     }
   }
 })
@@ -135,15 +146,6 @@ const applicationMenu: MenuItemConstructorOptions[] = [
         checked: config.get(ConfigKey.LaunchMinimized),
         click({ checked }: { checked: boolean }) {
           config.set(ConfigKey.LaunchMinimized, checked)
-        }
-      },
-      {
-        label: 'Hide Menu bar',
-        type: 'checkbox',
-        checked: config.get(ConfigKey.AutoHideMenuBar),
-        click({ checked }: { checked: boolean }) {
-          config.set(ConfigKey.AutoHideMenuBar, checked)
-          setAppMenuBarVisibility()
         }
       },
       {

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -6,7 +6,7 @@ import { checkForUpdates } from './updates'
 import config, { ConfigKey } from './config'
 import { setCustomStyle, USER_CUSTOM_STYLE_PATH } from './custom-styles'
 import { viewLogs } from './logs'
-import { showRestartDialog } from './utils'
+import { showRestartDialog, setAppMenuBarVisibility } from './utils'
 
 const APP_NAME = app.getName()
 
@@ -135,6 +135,15 @@ const applicationMenu: MenuItemConstructorOptions[] = [
         checked: config.get(ConfigKey.LaunchMinimized),
         click({ checked }: { checked: boolean }) {
           config.set(ConfigKey.LaunchMinimized, checked)
+        }
+      },
+      {
+        label: 'Hide Menu bar',
+        type: 'checkbox',
+        checked: config.get(ConfigKey.AutoHideMenuBar),
+        click({ checked }: { checked: boolean }) {
+          config.set(ConfigKey.AutoHideMenuBar, checked)
+          setAppMenuBarVisibility()
         }
       },
       {

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -24,11 +24,6 @@ const appearanceMenuItems: AppearanceMenuItem[] = [
     restartDialogText: 'compact header'
   },
   {
-    key: ConfigKey.AutoHideMenuBar,
-    label: 'Hide Menu bar',
-    setMenuBarVisibility: true
-  },
-  {
     key: ConfigKey.HideFooter,
     label: 'Hide Footer'
   },
@@ -67,6 +62,14 @@ const createAppearanceMenuItem = ({
     }
   }
 })
+
+if (is.linux || is.windows) {
+  appearanceMenuItems.unshift({
+    key: ConfigKey.AutoHideMenuBar,
+    label: 'Hide Menu bar',
+    setMenuBarVisibility: true
+  })
+}
 
 const applicationMenu: MenuItemConstructorOptions[] = [
   {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,10 +7,16 @@ export function getMainWindow(): BrowserWindow {
 
 export function setAppMenuBarVisibility(): void {
   const mainWindow = getMainWindow()
-  if (mainWindow) {
-    const isAppMenuBarVisible = config.get(ConfigKey.AutoHideMenuBar)
-    mainWindow.setMenuBarVisibility(!isAppMenuBarVisible)
-    mainWindow.setAutoHideMenuBar(isAppMenuBarVisible)
+  const isAppMenuBarVisible = config.get(ConfigKey.AutoHideMenuBar)
+  mainWindow.setMenuBarVisibility(!isAppMenuBarVisible)
+  mainWindow.setAutoHideMenuBar(isAppMenuBarVisible)
+
+  if (isAppMenuBarVisible) {
+    dialog.showMessageBox({
+      type: 'info',
+      buttons: ['OK'],
+      message: 'Tip: You can press the Alt key to see the Menu bar again.'
+    })
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,17 @@
 import { app, BrowserWindow, dialog } from 'electron'
+import config, { ConfigKey } from './config'
 
 export function getMainWindow(): BrowserWindow {
   return BrowserWindow.getAllWindows()[0]
+}
+
+export function setAppMenuBarVisibility(): void {
+  const mainWindow = getMainWindow()
+  if (mainWindow) {
+    const isAppMenuBarVisible = config.get(ConfigKey.AutoHideMenuBar)
+    mainWindow.setMenuBarVisibility(!isAppMenuBarVisible)
+    mainWindow.setAutoHideMenuBar(isAppMenuBarVisible)
+  }
 }
 
 export function sendChannelToMainWindow(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,13 +5,13 @@ export function getMainWindow(): BrowserWindow {
   return BrowserWindow.getAllWindows()[0]
 }
 
-export function setAppMenuBarVisibility(): void {
+export function setAppMenuBarVisibility(showTip?: boolean): void {
   const mainWindow = getMainWindow()
   const isAppMenuBarVisible = config.get(ConfigKey.AutoHideMenuBar)
   mainWindow.setMenuBarVisibility(!isAppMenuBarVisible)
   mainWindow.setAutoHideMenuBar(isAppMenuBarVisible)
 
-  if (isAppMenuBarVisible) {
+  if (isAppMenuBarVisible && showTip) {
     dialog.showMessageBox({
       type: 'info',
       buttons: ['OK'],


### PR DESCRIPTION
This fixes #88 by adding a configurable option to set the visibility of the Menu bar for those who want to change it.

When the Menu bar is hidden, we can hit the Alt key once to bring it up.

![image](https://user-images.githubusercontent.com/12471103/65963807-22f26f00-e479-11e9-857d-87ee531453c8.png)


With Menu bar visible (current look):

![image](https://user-images.githubusercontent.com/12471103/65960819-f176a500-e472-11e9-811e-224dd6c95164.png)

With Menu bar hidden (new look):

![image](https://user-images.githubusercontent.com/12471103/65960842-ff2c2a80-e472-11e9-9508-5481ceb92d10.png)

Thoughts?