### PR TITLE
Unread count for greater than 9 emails

### DIFF
--- a/src/preload.ts
+++ b/src/preload.ts
@@ -21,7 +21,7 @@ function getUnreadCount(): number {
 
     // Return the unread count (0 by default)
     if (label) {
-      return Number(/\d/.exec(label.innerText))
+      return Number(/\d*/.exec(label.innerText))
     }
   }
 


### PR DESCRIPTION
The regex for the unread count was only catching single number values.