### PR TITLE
fix #167 by creating tray items on woedows too

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -181,7 +181,7 @@ app.on('ready', () => {
       }
     ]
 
-    if (is.linux) {
+    if (is.linux || is.windows) {
       contextMenuTemplate.unshift(
         {
           click: () => {


### PR DESCRIPTION
Bug description:

On WIndows, and Linux, the Tray context menu displays a "Hide/Show" item, but due to a coding error, that item wasn't created on Windows and thus lead to a null reference error at runtime for Windows users. This PR fixes that by creating the said Tray item on both Windows and Linux and thus closes #167 .