### PR TITLE
adding quick actions dock menu for macOS

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -23,6 +23,7 @@ import { platform, getUrlAccountId, createTrayIcon } from './helpers'
 import menu from './menu'
 import { setAppMenuBarVisibility, cleanURLFromGoogle } from './utils'
 import ensureOnline from './ensure-online'
+import { buildDockMenu } from './dock-menu'
 
 import electronContextMenu = require('electron-context-menu')
 
@@ -132,6 +133,10 @@ function createWindow(): void {
       }
     }
   })
+
+  if (is.macos) {
+    app.dock.setMenu(buildDockMenu(mainWindow))
+  }
 }
 
 function createMailto(url: string): void {

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import {
   app,
-  ipcMain as ipc,
+  ipcMain,
   shell,
   BrowserWindow,
   Menu,
@@ -121,7 +121,7 @@ function createWindow(): void {
     }
   }
 
-  ipc.on('unread-count', (_: Event, unreadCount: number) => {
+  ipcMain.on('unread-count', (_: Event, unreadCount: number) => {
     if (is.macos) {
       app.dock.setBadge(unreadCount ? unreadCount.toString() : '')
     }
@@ -137,6 +137,11 @@ function createWindow(): void {
   if (is.macos) {
     app.dock.setMenu(buildDockMenu(mainWindow))
   }
+
+  // TODO: create ipcMain.on(..) events for opening inbox,compose, and sent views
+  ipcMain.on('open-inbox-view', () => {
+    console.log('INBOX VIEW CLICKED')
+  })
 }
 
 function createMailto(url: string): void {

--- a/src/dock-menu.ts
+++ b/src/dock-menu.ts
@@ -1,22 +1,25 @@
-import { Menu, BrowserWindow, MenuItemConstructorOptions } from 'electron'
+import {
+  BrowserWindow,
+  Menu,
+  MenuItemConstructorOptions,
+  ipcRenderer as ipc
+} from 'electron'
 
 const baseGmailUrl = 'https://mail.google.com'
 
 export function buildDockMenu(mainWindow: BrowserWindow): Menu {
-  const inboxButton = createInboxButton(mainWindow)
+  const inboxButton = createInboxButton()
   const composeButton = createComposeButton(mainWindow)
   const sentButton = createSentButton(mainWindow)
   return Menu.buildFromTemplate([inboxButton, composeButton, sentButton])
 }
 
-function createInboxButton(
-  mainWindow: BrowserWindow
-): MenuItemConstructorOptions {
+function createInboxButton(): MenuItemConstructorOptions {
   return {
     label: 'Inbox',
-    async click() {
-      await mainWindow.loadURL(`${baseGmailUrl}/#inbox`)
-      mainWindow.show()
+    click() {
+      // TODO: investigate why ipc is undefined here
+      ipc.send('open-inbox-view')
     }
   }
 }

--- a/src/dock-menu.ts
+++ b/src/dock-menu.ts
@@ -1,5 +1,7 @@
 import { Menu, BrowserWindow, MenuItemConstructorOptions } from 'electron'
 
+const baseGmailUrl = 'https://mail.google.com'
+
 export function buildDockMenu(mainWindow: BrowserWindow): Menu {
   const inboxButton = createInboxButton(mainWindow)
   const composeButton = createComposeButton(mainWindow)
@@ -13,7 +15,7 @@ function createInboxButton(
   return {
     label: 'Inbox',
     async click() {
-      await mainWindow.loadURL('https://mail.google.com/#inbox')
+      await mainWindow.loadURL(`${baseGmailUrl}/#inbox`)
       mainWindow.show()
     }
   }
@@ -25,7 +27,7 @@ function createComposeButton(
   return {
     label: 'Compose',
     async click() {
-      await mainWindow.loadURL('https://mail.google.com/#inbox?compose=new')
+      await mainWindow.loadURL(`${baseGmailUrl}/#inbox?compose=new`)
       mainWindow.show()
     }
   }
@@ -37,7 +39,7 @@ function createSentButton(
   return {
     label: 'Sent',
     async click() {
-      await mainWindow.loadURL('https://mail.google.com/#sent')
+      await mainWindow.loadURL(`${baseGmailUrl}/#sent`)
       mainWindow.show()
     }
   }

--- a/src/dock-menu.ts
+++ b/src/dock-menu.ts
@@ -1,0 +1,44 @@
+import { Menu, BrowserWindow, MenuItemConstructorOptions } from 'electron'
+
+export function buildDockMenu(mainWindow: BrowserWindow): Menu {
+  const inboxButton = createInboxButton(mainWindow)
+  const composeButton = createComposeButton(mainWindow)
+  const sentButton = createSentButton(mainWindow)
+  return Menu.buildFromTemplate([inboxButton, composeButton, sentButton])
+}
+
+function createInboxButton(
+  mainWindow: BrowserWindow
+): MenuItemConstructorOptions {
+  return {
+    label: 'Inbox',
+    async click() {
+      await mainWindow.loadURL('https://mail.google.com/#inbox')
+      mainWindow.show()
+    }
+  }
+}
+
+function createComposeButton(
+  mainWindow: BrowserWindow
+): MenuItemConstructorOptions {
+  return {
+    label: 'Compose',
+    async click() {
+      await mainWindow.loadURL('https://mail.google.com/#inbox?compose=new')
+      mainWindow.show()
+    }
+  }
+}
+
+function createSentButton(
+  mainWindow: BrowserWindow
+): MenuItemConstructorOptions {
+  return {
+    label: 'Sent',
+    async click() {
+      await mainWindow.loadURL('https://mail.google.com/#sent')
+      mainWindow.show()
+    }
+  }
+}


### PR DESCRIPTION
Hi!

I worked on Caprine, and I noticed that this app takes a lot of inspiration from it. I took a hand at implementing #79.  I created dock menu options for 

* `Compose`
* `Inbox`
* `Sent`

But I didn't create one for `All mail`, since I thought that was a bit redundant when we already have the `Inbox` option. Thanks!