### PR TITLE
Fix 'hide menu bar' menu item

### DIFF
--- a/src/main/menus/app.ts
+++ b/src/main/menus/app.ts
@@ -114,6 +114,8 @@ export function getAppMenu() {
             {
               label: 'Hide Menu bar',
               visible: !is.macos,
+              type: 'checkbox',
+              checked: config.get(ConfigKey.AutoHideMenuBar),
               click({ checked }) {
                 config.set(ConfigKey.AutoHideMenuBar, checked)
                 const mainWindow = getMainWindow()


### PR DESCRIPTION
Leaves empty space on top once disabled, and after restarting the app, once activated with Alt, fails to render, can only see the outline around the items. Once one of the items is selected, though, the submenu renders correctly. But this is a separate issue.