### PR TITLE
Fix missing application icon on Linux

### DIFF
--- a/src/main/main-window/index.ts
+++ b/src/main/main-window/index.ts
@@ -55,7 +55,7 @@ export function createMainWindow(): void {
     },
     show: !shouldLaunchMinimized(),
     icon: is.linux
-      ? path.join(__dirname, '..', 'static', 'icon.png')
+      ? path.join(__dirname, '..', '..', 'static', 'icon.png')
       : undefined,
     darkTheme: nativeTheme.shouldUseDarkColors,
     backgroundColor: nativeTheme.shouldUseDarkColors


### PR DESCRIPTION
When running gmail-desktop on Linux/X11 a generic fallback icon is shown in the titlebar.  The path for the included icon appears to be slightly off.  This PR changes the path to fix that problem.

Before:
![before](https://user-images.githubusercontent.com/43704682/152710191-a83018b6-b7ee-4b00-9fdf-12ec091718c9.png)

After:
![after](https://user-images.githubusercontent.com/43704682/152710198-b8a6542d-7baa-489e-9539-4a97654e54ef.png)
