### PR TITLE
fix label icons

### DIFF
--- a/src/main/account-views/custom-styles/style.css
+++ b/src/main/account-views/custom-styles/style.css
@@ -128,3 +128,20 @@
   width: 26px !important;
   height: 26px !important;
 }
+
+/* Labels */
+.aEe,
+.aEc.aHS-bnr .qj {
+  -webkit-mask: url('https://www.gstatic.com/images/icons/material/system_gm_filled/1x/label_gm_grey_24dp.png')
+    center/contain;
+}
+
+/* stylelint-disable media-feature-name-no-unknown */
+@media (min-resolution: 144dpi), (min-device-pixel-ratio: 1.5) {
+  .aEe,
+  .aEc.aHS-bnr .qj {
+    -webkit-mask: url('https://www.gstatic.com/images/icons/material/system_gm_filled/2x/label_gm_grey_24dp.png')
+      center/contain;
+  }
+}
+/* stylelint-enable media-feature-name-no-unknown */

--- a/src/main/account-views/preload/dark-mode.ts
+++ b/src/main/account-views/preload/dark-mode.ts
@@ -51,7 +51,9 @@ function enableDarkMode(): void {
         // Hangouts Conversations
         '.aj2',
         // Hangouts Phone
-        '.a8V'
+        '.a8V',
+        /* Labels */
+        '.aEe, .aEc.aHS-bnr .qj'
       ]
     }
   )


### PR DESCRIPTION
Label icons on the left bar show up as boxes.

For some reason, the css `mask` property is showing as invalid, even in newer versions of electron.

I copied the broken css selector from its source in the dev tools, changed `mask` to `-webkit-mask`, and added it to the custom stylesheet.

The labels now show up correctly in light mode.

Dark mode is a bit funky. The purple label is a slightly lighter grey than the other default coloured labels. The correct behaviour would be to leave the coloured labels untouched.

Before:

![Labels Before](https://user-images.githubusercontent.com/510163/153133212-4335ee29-98fe-484e-b2df-235148934d0c.png)

After:

![Labels After](https://user-images.githubusercontent.com/510163/153133256-f543c49d-8999-4f91-bc0d-fe5fabb7fb46.png)

CSS:

![Labels CSS](https://user-images.githubusercontent.com/510163/153132621-631e4a28-0f17-4513-9916-2b26323f558c.png)