### PR TITLE
fix settings button alignment in compact header

### DIFF
--- a/src/main/account-views/custom-styles/style.css
+++ b/src/main/account-views/custom-styles/style.css
@@ -87,8 +87,8 @@
   > div:last-of-type
   > div:last-of-type
   > a {
-  padding: 4px !important;
-  margin: 0 !important;
+  padding: 8px !important;
+  margin: 2px !important;
 }
 
 /* Header: Account */


### PR DESCRIPTION
I simply took the padding and margin values from here:

![chrome info](https://user-images.githubusercontent.com/510163/153629975-6ac79fe0-9057-47aa-90f2-9f464d78c1c4.png)

And it just worked...

Before:
<img width="320" alt="mac before" src="https://user-images.githubusercontent.com/510163/153630185-576d9ff0-35e1-4e4c-943e-37dba1e954b1.png">

After:
<img width="320" alt="mac after" src="https://user-images.githubusercontent.com/510163/153630192-14bd64f8-a843-4ecd-9f22-b4c82d3a65a9.png">

Tested on Mac and Windows.
