### PR TITLE
fix google chat status in compact header mode

### DIFF
--- a/src/main/account-views/custom-styles/style.css
+++ b/src/main/account-views/custom-styles/style.css
@@ -177,6 +177,39 @@
   height: 26px !important;
 }
 
+/* Header: Google Chat status button */
+.compactHeader
+  header
+  > div:nth-child(2)
+  > div:nth-child(2)
+  > div:last-of-type
+  div[role='button'] {
+  height: 28px !important;
+  bottom: 4px !important;
+}
+
+/* Header: Google Chat status text and icon */
+.compactHeader
+  header
+  > div:nth-child(2)
+  > div:nth-child(2)
+  > div:last-of-type
+  > div[role='button']
+  > div:nth-child(1) {
+  bottom: 5px !important;
+}
+
+/* Header: Google Chat status dropdown arrow */
+.compactHeader
+  header
+  > div:nth-child(2)
+  > div:nth-child(2)
+  > div:last-of-type
+  > div[role='button']
+  > svg:nth-child(2) {
+  top: 1px !important;
+}
+
 /* Labels */
 .aEe,
 .aEc.aHS-bnr .qj {


### PR DESCRIPTION
Here it is:
<img width="320" alt="Screenshots of fixed compact header bar" src="https://user-images.githubusercontent.com/510163/153696037-4644f335-1515-4039-a344-a7767373f2a0.png">
