### PR TITLE
improve the look of the sign-in page in dark mode

### DIFF
--- a/src/main/account-views/preload/dark-mode.ts
+++ b/src/main/account-views/preload/dark-mode.ts
@@ -36,6 +36,29 @@ function enableDarkMode(): void {
           .z0 > .L3 {
             background-color: ${darkTheme.bg[1]} !important;
           }
+
+          /* Sign-in page - remove weird filled sections */
+          div#view_container > div > div[role='presentation'] > div[role='presentation'] > div[role='presentation'] {
+            border-color: transparent !important;
+          }
+
+          /* Sign-in page - fix border */
+          div#initialView > * {
+            background-color: transparent !important;
+            border-color: #776e62 !important; // Hard-coded border color
+          }
+
+          /* Sign-in page - add border to some buttons */
+          .VfPpkd-LgbsSe.VfPpkd-LgbsSe-OWXEXe-k8QpJ.VfPpkd-LgbsSe-OWXEXe-dgl2Hf.nCP5yc.AjY5Oe.DuMIQc.qIypjc.TrZEUc.lw1w4b {
+            border: 1px #776e62 solid !important; // Hard-coded border color
+            border-radius: 8px !important;
+          }
+
+          /* Sign-in page - fix button borders */
+          .VfPpkd-RLmnJb,
+          .VfPpkd-Jh9lGc {
+            background-color: transparent !important;
+          }
         `,
       ignoreImageAnalysis: [],
       ignoreInlineStyle: [],

--- a/src/main/account-views/preload/dark-mode.ts
+++ b/src/main/account-views/preload/dark-mode.ts
@@ -48,7 +48,7 @@ function enableDarkMode(): void {
             border-color: #776e62 !important; // Hard-coded border color
           }
 
-          /* Sign-in page - add border to some buttons */
+          /* [Custom User Agent only] Sign-in page - add border to some buttons */
           .VfPpkd-LgbsSe.VfPpkd-LgbsSe-OWXEXe-k8QpJ.VfPpkd-LgbsSe-OWXEXe-dgl2Hf.nCP5yc.AjY5Oe.DuMIQc.qIypjc.TrZEUc.lw1w4b {
             border: 1px #776e62 solid !important; // Hard-coded border color
             border-radius: 8px !important;

--- a/src/main/account-views/preload/dark-mode.ts
+++ b/src/main/account-views/preload/dark-mode.ts
@@ -42,7 +42,7 @@ function enableDarkMode(): void {
             border-color: transparent !important;
           }
 
-          /* [Custom User Agent only] Sign-in page - fix border */
+          /* [Custom User Agent only] Sign-in page: Fix border */
           div#initialView > * {
             background-color: transparent !important;
             border-color: #776e62 !important; // Hard-coded border color

--- a/src/main/account-views/preload/dark-mode.ts
+++ b/src/main/account-views/preload/dark-mode.ts
@@ -54,7 +54,7 @@ function enableDarkMode(): void {
             border-radius: 8px !important;
           }
 
-          /* [Custom User Agent only] Sign-in page - fix button borders */
+          /* [Custom User Agent only] Sign-in page: Fix buttons */
           .VfPpkd-RLmnJb,
           .VfPpkd-Jh9lGc {
             background-color: transparent !important;

--- a/src/main/account-views/preload/dark-mode.ts
+++ b/src/main/account-views/preload/dark-mode.ts
@@ -54,7 +54,7 @@ function enableDarkMode(): void {
             border-radius: 8px !important;
           }
 
-          /* Sign-in page - fix button borders */
+          /* [Custom User Agent only] Sign-in page - fix button borders */
           .VfPpkd-RLmnJb,
           .VfPpkd-Jh9lGc {
             background-color: transparent !important;

--- a/src/main/account-views/preload/dark-mode.ts
+++ b/src/main/account-views/preload/dark-mode.ts
@@ -42,7 +42,7 @@ function enableDarkMode(): void {
             border-color: transparent !important;
           }
 
-          /* Sign-in page - fix border */
+          /* [Custom User Agent only] Sign-in page - fix border */
           div#initialView > * {
             background-color: transparent !important;
             border-color: #776e62 !important; // Hard-coded border color

--- a/src/main/account-views/preload/dark-mode.ts
+++ b/src/main/account-views/preload/dark-mode.ts
@@ -37,7 +37,7 @@ function enableDarkMode(): void {
             background-color: ${darkTheme.bg[1]} !important;
           }
 
-          /* Sign-in page - remove weird filled sections */
+          /* [Custom User Agent only] Sign-in page - remove weird filled sections */
           div#view_container > div > div[role='presentation'] > div[role='presentation'] > div[role='presentation'] {
             border-color: transparent !important;
           }

--- a/src/main/account-views/preload/dark-mode.ts
+++ b/src/main/account-views/preload/dark-mode.ts
@@ -48,7 +48,7 @@ function enableDarkMode(): void {
             border-color: #776e62 !important; // Hard-coded border color
           }
 
-          /* [Custom User Agent only] Sign-in page - add border to some buttons */
+          /* [Custom User Agent only] Sign-in page: Buttons */
           .VfPpkd-LgbsSe.VfPpkd-LgbsSe-OWXEXe-k8QpJ.VfPpkd-LgbsSe-OWXEXe-dgl2Hf.nCP5yc.AjY5Oe.DuMIQc.qIypjc.TrZEUc.lw1w4b {
             border: 1px #776e62 solid !important; // Hard-coded border color
             border-radius: 8px !important;

--- a/src/main/account-views/preload/dark-mode.ts
+++ b/src/main/account-views/preload/dark-mode.ts
@@ -37,7 +37,7 @@ function enableDarkMode(): void {
             background-color: ${darkTheme.bg[1]} !important;
           }
 
-          /* [Custom User Agent only] Sign-in page - remove weird filled sections */
+          /* [Custom User Agent only] Sign-in page: Random filled sections */
           div#view_container > div > div[role='presentation'] > div[role='presentation'] > div[role='presentation'] {
             border-color: transparent !important;
           }


### PR DESCRIPTION
The code is a bit janky, but the screenshots are pretty.

Before:
<img width="500" alt="before" src="https://user-images.githubusercontent.com/510163/153696390-a39b7e1e-b4fc-43a3-951f-3302f29959dd.png">
After:
<img width="500" alt="after" src="https://user-images.githubusercontent.com/510163/153696394-914608db-5257-45d6-a6f3-88ecd131ed80.png">
Light mode for reference:
<img width="500" alt="light" src="https://user-images.githubusercontent.com/510163/153696397-43e2e06e-b513-426a-84e1-024e5fb651ab.png">

