### PR TITLE
open main window on some actions (macOS)

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -49,6 +49,12 @@ export async function initApp() {
 
   app.on('open-url', (_event, mailto) => {
     sendToSelectedAccountView('gmail:compose-mail', mailto.split(':')[1])
+
+    const mainWindow = getMainWindow()
+
+    if (mainWindow) {
+      mainWindow.show()
+    }
   })
 
   app.on('activate', () => {

--- a/src/main/menus/app.ts
+++ b/src/main/menus/app.ts
@@ -460,6 +460,8 @@ export function getAppMenu() {
           accelerator: 'Command+,',
           click() {
             sendToSelectedAccountView('gmail:go-to', 'settings')
+            const mainWindow = getMainWindow()
+            mainWindow.show()
           }
         },
         {
@@ -498,6 +500,8 @@ export function getAppMenu() {
           label: 'Compose',
           click() {
             sendToSelectedAccountView('gmail:compose-mail')
+            const mainWindow = getMainWindow()
+            mainWindow.show()
           }
         },
         {
@@ -520,6 +524,8 @@ export function getAppMenu() {
           click() {
             sendToMainWindow('add-account-request')
             hideAccountViews()
+            const mainWindow = getMainWindow()
+            mainWindow.show()
           }
         },
         {
@@ -529,6 +535,8 @@ export function getAppMenu() {
             if (selectedAccount) {
               sendToMainWindow('edit-account-request', selectedAccount)
               hideAccountViews()
+              const mainWindow = getMainWindow()
+              mainWindow.show()
             }
           }
         },
@@ -538,6 +546,9 @@ export function getAppMenu() {
             const selectedAccount = getSelectedAccount()
 
             if (selectedAccount) {
+              const mainWindow = getMainWindow()
+              mainWindow.show()
+
               if (isDefaultAccount(selectedAccount.id)) {
                 dialog.showMessageBox({
                   type: 'info',


### PR DESCRIPTION
On Mac, you can press Cmd+W to close the window, and still access the menu bar. Some options which I expected to reopen the main window didn't do so, but others did.

Now, the main window will open/focus when you press any of: Gmail Settings, Add Account, Edit Account, Remove Account.

It will also open/focus when handling a mailto link.