### PR TITLE
Fix/move google chat status menu

### DIFF
--- a/src/main/account-views/custom-styles/style.css
+++ b/src/main/account-views/custom-styles/style.css
@@ -213,8 +213,12 @@
 }
 
 /* Header: Google Chat status dropdown menu */
-.compactHeader .tP {
+body:not([dir='rtl']).compactHeader .tP {
   transform: translateX(-100px);
+}
+
+body[dir='rtl'].compactHeader .tP {
+  transform: translateX(100px);
 }
 
 /* Header: Google One account ring */

--- a/src/main/account-views/custom-styles/style.css
+++ b/src/main/account-views/custom-styles/style.css
@@ -213,13 +213,11 @@
 }
 
 /* Header: Google Chat status dropdown menu */
-:not([dir='rtl']).gmail-desktop_compact-header
-  [style*='top:'][style*='left:'][style*='visibility:'] {
+:not([dir='rtl']).gmail-desktop_compact-header .tP {
   transform: translateX(-100px);
 }
 
-[dir='rtl'].gmail-desktop_compact-header
-  [style*='top:'][style*='left:'][style*='visibility:'] {
+[dir='rtl'].gmail-desktop_compact-header .tP {
   transform: translateX(100px);
 }
 

--- a/src/main/account-views/custom-styles/style.css
+++ b/src/main/account-views/custom-styles/style.css
@@ -212,6 +212,11 @@
   top: 1px !important;
 }
 
+/* Header: Google Chat status dropdown menu */
+.compactHeader .tP {
+  transform: translateX(-100px);
+}
+
 /* Header: Google One account ring */
 .compactHeader
   header

--- a/src/main/account-views/custom-styles/style.css
+++ b/src/main/account-views/custom-styles/style.css
@@ -213,11 +213,13 @@
 }
 
 /* Header: Google Chat status dropdown menu */
-body:not([dir='rtl']).gmail-desktop_compact-header .tP {
+:not([dir='rtl']).gmail-desktop_compact-header
+  [style*='top:'][style*='left:'][style*='visibility:'] {
   transform: translateX(-100px);
 }
 
-body[dir='rtl'].gmail-desktop_compact-header.tP {
+[dir='rtl'].gmail-desktop_compact-header
+  [style*='top:'][style*='left:'][style*='visibility:'] {
   transform: translateX(100px);
 }
 

--- a/src/main/account-views/custom-styles/style.css
+++ b/src/main/account-views/custom-styles/style.css
@@ -213,11 +213,11 @@
 }
 
 /* Header: Google Chat status dropdown menu */
-body:not([dir='rtl']).compactHeader .tP {
+body:not([dir='rtl']).gmail-desktop_compact-header .tP {
   transform: translateX(-100px);
 }
 
-body[dir='rtl'].compactHeader .tP {
+body[dir='rtl'].gmail-desktop_compact-header.tP {
   transform: translateX(100px);
 }
 


### PR DESCRIPTION
The position of the Google Chat status dropdown is calculated in javascript. When compact header mode is enabled, it isn't positioned correctly, presumably because of the elements we've hidden.

They position it with the `top` and `left` properties, so I've used `transform: translateX(-100px)` to apply a constant offset.

Before:
<img height="300" alt="before narrow" src="https://user-images.githubusercontent.com/510163/153748394-2e5f0520-fa9a-469e-90e6-39f39140a743.png">
<img height="300" alt="before wide" src="https://user-images.githubusercontent.com/510163/153748396-69ac7881-52a4-467f-95d0-965858664935.png">
After:
<img height="300" alt="fixed narrow" src="https://user-images.githubusercontent.com/510163/153748673-a3f0ecc5-11cd-414b-92be-d4b6fd41fef5.png">
<img height="300" alt="fixed wide" src="https://user-images.githubusercontent.com/510163/153748403-46f62224-b5d9-4431-97fb-f6c216179f3d.png">
And when `<body dir='rtl'>`:
<img height="300" alt="arabic" src="https://user-images.githubusercontent.com/510163/153748457-dcf10866-02ad-4748-83f4-2594295ca98c.png">

