### PR TITLE
use hide window buttons on macos only

### DIFF
--- a/src/main/menus/app.ts
+++ b/src/main/menus/app.ts
@@ -50,6 +50,24 @@ interface AppearanceMenuItem {
 }
 
 export function getAppMenu() {
+  const macOSWindowItems: MenuItemConstructorOptions[] = [
+    {
+      label: `Hide ${app.name}`,
+      role: 'hide'
+    },
+    {
+      label: 'Hide Others',
+      role: 'hideOthers'
+    },
+    {
+      label: 'Show All',
+      role: 'unhide'
+    },
+    {
+      type: 'separator'
+    }
+  ]
+
   const appearanceMenuItems: AppearanceMenuItem[] = [
     {
       key: ConfigKey.CompactHeader,
@@ -470,29 +488,7 @@ export function getAppMenu() {
         {
           type: 'separator'
         },
-        {
-          label: `Hide ${app.name}`,
-          visible: is.macos,
-          role: 'hide'
-        },
-        {
-          label: 'Hide Others',
-          visible: is.macos,
-          role: 'hideOthers'
-        },
-        {
-          label: 'Show All',
-          visible: is.macos,
-          role: 'unhide'
-        },
-        is.macos
-          ? {
-              type: 'separator'
-            }
-          : {
-              label: 'hidden separator',
-              visible: false
-            },
+        ...(is.macos ? macOSWindowItems : []),
         {
           label: `Quit ${app.name}`,
           accelerator: 'CommandOrControl+Q',

--- a/src/main/menus/app.ts
+++ b/src/main/menus/app.ts
@@ -472,21 +472,27 @@ export function getAppMenu() {
         },
         {
           label: `Hide ${app.name}`,
-          accelerator: 'CommandOrControl+H',
+          visible: is.macos,
           role: 'hide'
         },
         {
           label: 'Hide Others',
-          accelerator: 'CommandOrControl+Shift+H',
+          visible: is.macos,
           role: 'hideOthers'
         },
         {
           label: 'Show All',
+          visible: is.macos,
           role: 'unhide'
         },
-        {
-          type: 'separator'
-        },
+        is.macos
+          ? {
+              type: 'separator'
+            }
+          : {
+              label: 'hidden separator',
+              visible: false
+            },
         {
           label: `Quit ${app.name}`,
           accelerator: 'CommandOrControl+Q',


### PR DESCRIPTION
I don't think the "Hide", "Hide Others" and "Show All" buttons do anything on Windows or Linux.

I removed the "Hide" and "Hide Others" accelerators because they are provided by default on macOS. "Hide Others" now gets set to `Command+Option+H` instead of `Command+Shift+H`. (Safari and Chrome use `Command+Shift+H` to go Home, so we could potentially use that hotkey to go to the inbox or something.)

The `visible` property doesn't hide separators (electron/electron#3494), so I've used a quick and dirty solution.