### PR TITLE
Make it clear that you need to enable desktop notifications in Gmail

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - [Menu bar mode](#menu-bar-mode-macos) _(macOS)_
 - Unread badge in dock _(macOS)_
 - Unread icon in tray _(Linux/Windows)_
-- Desktop notifications (you must [enable desktop notifications in Gmail](https://support.google.com/mail/answer/1075549?co=GENIE.Platform%3DDesktop) for this to work)
+- Desktop notifications (["New mail notifications on" must be enabled](https://support.google.com/mail/answer/1075549?co=GENIE.Platform%3DDesktop) in Gmail settings)
 - Silent auto-updates
 - Cross-platform
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - [Menu bar mode](#menu-bar-mode-macos) _(macOS)_
 - Unread badge in dock _(macOS)_
 - Unread icon in tray _(Linux/Windows)_
-- Desktop notifications (you must [enable desktop notifications in Gmail](https://support.google.com/mail/answer/1075549?hl=en-GB&co=GENIE.Platform%3DDesktop) for this to work)
+- Desktop notifications (you must [enable desktop notifications in Gmail](https://support.google.com/mail/answer/1075549?co=GENIE.Platform%3DDesktop) for this to work)
 - Silent auto-updates
 - Cross-platform
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - [Menu bar mode](#menu-bar-mode-macos) _(macOS)_
 - Unread badge in dock _(macOS)_
 - Unread icon in tray _(Linux/Windows)_
-- Desktop notifications
+- Desktop notifications (you must [enable desktop notifications in Gmail](https://support.google.com/mail/answer/1075549?hl=en-GB&co=GENIE.Platform%3DDesktop) for this to work)
 - Silent auto-updates
 - Cross-platform
 


### PR DESCRIPTION
Made it clear that you need to enable desktop notifications in Gmail for notifications to work. Otherwise I would just assume that notifications are on by default (like in the official Android app).