### PR TITLE
Add menu items for next/previous account selection

### DIFF
--- a/src/main/accounts.ts
+++ b/src/main/accounts.ts
@@ -35,6 +35,35 @@ export function getSelectedAccount() {
   return getAccounts().find(({ selected }) => selected)
 }
 
+export function getSelectedAccountIndex() {
+  return getAccounts().findIndex(({ selected }) => selected)
+}
+
+export function selectNextAccount() {
+  const accounts = getAccounts()
+  const selectedAccountIndex = getSelectedAccountIndex()
+  const nextAccount = accounts[selectedAccountIndex + 1] ?? accounts[0]
+
+  if (!nextAccount) {
+    return
+  }
+
+  selectAccount(nextAccount.id)
+}
+
+export function selectPreviousAccount() {
+  const accounts = getAccounts()
+  const selectedAccountIndex = getSelectedAccountIndex()
+  const previousAccount =
+    accounts[selectedAccountIndex - 1] ?? accounts[accounts.length - 1]
+
+  if (!previousAccount) {
+    return
+  }
+
+  selectAccount(previousAccount.id)
+}
+
 export function selectAccount(accountId: string) {
   const accounts = getAccounts().map((account) => ({
     ...account,

--- a/src/main/menus/app.ts
+++ b/src/main/menus/app.ts
@@ -30,7 +30,9 @@ import {
   getAccountsMenuItems,
   getSelectedAccount,
   isDefaultAccount,
-  removeAccount
+  removeAccount,
+  selectNextAccount,
+  selectPreviousAccount
 } from '../accounts'
 import { getMainWindow, sendToMainWindow, showMainWindow } from '../main-window'
 import {
@@ -520,6 +522,65 @@ export function getAppMenu() {
       label: 'Account',
       submenu: [
         ...getAccountsMenuItems(true),
+        {
+          type: 'separator'
+        },
+        {
+          label: 'Select Next Account',
+          accelerator: 'Ctrl+Tab',
+          click() {
+            selectNextAccount()
+            showMainWindow()
+          }
+        },
+        {
+          label: 'Select Next Account (hidden shortcut 1)',
+          accelerator: 'Cmd+Shift+]',
+          visible: is.development,
+          acceleratorWorksWhenHidden: true,
+          click() {
+            selectNextAccount()
+            showMainWindow()
+          }
+        },
+        {
+          label: 'Select Next Account (hidden shortcut 1)',
+          accelerator: 'Cmd+Option+Right',
+          visible: is.development,
+          acceleratorWorksWhenHidden: true,
+          click() {
+            selectNextAccount()
+            showMainWindow()
+          }
+        },
+        {
+          label: 'Select Previous Account',
+          accelerator: 'Ctrl+Shift+Tab',
+          click() {
+            selectPreviousAccount()
+            showMainWindow()
+          }
+        },
+        {
+          label: 'Select Previous Account (hidden shortcut 1)',
+          accelerator: 'Cmd+Shift+[',
+          visible: is.development,
+          acceleratorWorksWhenHidden: true,
+          click() {
+            selectPreviousAccount()
+            showMainWindow()
+          }
+        },
+        {
+          label: 'Select Previous Account (hidden shortcut 2)',
+          accelerator: 'Cmd+Option+Left',
+          visible: is.development,
+          acceleratorWorksWhenHidden: true,
+          click() {
+            selectPreviousAccount()
+            showMainWindow()
+          }
+        },
         {
           type: 'separator'
         },


### PR DESCRIPTION
This PR adds menu bar items and keyboard shortcuts for native style tab navigation between accounts.

Note that both shortcuts are able to "cycle" back around, i.e. if you invoke "next" on the rightmost tab then the leftmost tab will be selected and vice-versa.

### Menu bar changes
<img width="519" alt="CleanShot 2022-11-15 at 10 56 32@2x" src="https://user-images.githubusercontent.com/241576/201903022-166efdf3-f09b-49ac-9098-5bc2f4b89cb2.png">

### Default shortcuts
![CleanShot 2022-11-15 at 10 56 12](https://user-images.githubusercontent.com/241576/201903045-46aac6d2-fc50-4a79-934e-78b3c90dfdd2.gif)

### Additional shortcuts
![CleanShot 2022-11-15 at 10 55 20](https://user-images.githubusercontent.com/241576/201903069-6f9de052-e932-4029-8dbc-8bf2ffbb276d.gif)
