### PR TITLE
downloads: use actual save path when opening

### DIFF
--- a/src/main/downloads.ts
+++ b/src/main/downloads.ts
@@ -1,5 +1,4 @@
 import { shell } from 'electron'
-import * as path from 'path'
 import electronDl = require('electron-dl')
 import config, { ConfigKey } from './config'
 import { createNotification } from './utils/notifications'
@@ -10,11 +9,10 @@ export function initDownloads(): void {
   const handleStarted = (item: Electron.DownloadItem) => {
     item.once('done', (_, state) => {
       const fileName = item.getFilename()
+      const filePath = item.getSavePath()
 
       createNotification(`Download ${state}`, fileName, () => {
-        shell.openPath(
-          path.join(config.get(ConfigKey.DownloadsLocation), fileName)
-        )
+        shell.openPath(filePath)
       })
     })
   }


### PR DESCRIPTION
Fix for #364 

using getSavePath to retrieve the downloaded files full path