### PR TITLE
allow back & forward navigation shortcuts on macos

### DIFF
--- a/src/main/main-window/index.ts
+++ b/src/main/main-window/index.ts
@@ -1,5 +1,11 @@
 import * as path from 'path'
-import { app, BrowserWindow, nativeTheme, ipcMain } from 'electron'
+import {
+  app,
+  BrowserWindow,
+  nativeTheme,
+  ipcMain,
+  globalShortcut
+} from 'electron'
 import { is } from 'electron-util'
 import config, { ConfigKey } from '../config'
 import { toggleAppVisiblityTrayItem } from '../tray'
@@ -120,6 +126,28 @@ export function createMainWindow(): void {
       selectedAccountView.webContents.focus()
     }
   })
+
+  // Register global shortcuts for navigating back and forward on macOS.
+  if (is.macos) {
+    mainWindow.on('focus', () => {
+      globalShortcut.register('Command+Left', () => {
+        const selectedAccountView = getSelectedAccountView()
+        if (selectedAccountView?.webContents.canGoBack()) {
+          selectedAccountView.webContents.goBack()
+        }
+      })
+
+      globalShortcut.register('Command+Right', () => {
+        const selectedAccountView = getSelectedAccountView()
+        if (selectedAccountView?.webContents.canGoForward()) {
+          selectedAccountView.webContents.goForward()
+        }
+      })
+    })
+    mainWindow.on('blur', () => {
+      globalShortcut.unregisterAll()
+    })
+  }
 
   let debouncedUpdateAllAccountViewBounds: () => void
 


### PR DESCRIPTION
Hello,

As mentioned in [this comment](https://github.com/timche/gmail-desktop/issues/293#issuecomment-1685395939), I noticed that there is no shortcut working for back/forward navigation on macOS.

Therefore, I have created this PR to enable the ⌘← / ⌘→ shortcuts exclusively for macOS.

This approach is based on a solution found [here](https://github.com/electron/electron/issues/8491#issuecomment-1002515761). I have tested it locally, and it works quite well.

However, there is one drawback: when editing a textarea (such as when writing an email), pressing ⌘← should not navigate to the previous page. Although it is still better than having no shortcut at all, it does not exactly match the behavior of a browser. One possible alternative would be to inject JavaScript directly into the mainWindow to detect whether it is in editing mode or not.