### PR TITLE
Activate first account with unread mail on tray icon click

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -310,6 +310,20 @@ class Accounts {
 			0,
 		);
 	}
+
+	getFirstAccountWithUnread() {
+		for (const accountConfig of this.getAccountConfigs()) {
+			const instance = this.instances.get(accountConfig.id);
+
+			if (instance) {
+				const unreadCount = instance.gmail.store.getState().unreadCount;
+
+				if (typeof unreadCount === "number" && unreadCount > 0) {
+					return accountConfig;
+				}
+			}
+		}
+	}
 }
 
 export const accounts = new Accounts();

--- a/packages/app/tray.ts
+++ b/packages/app/tray.ts
@@ -31,6 +31,12 @@ export class AppTray {
 				this.tray.setContextMenu(this.menu);
 			} else {
 				this.tray.on("click", () => {
+					const accountWithUnread = accounts.getFirstAccountWithUnread();
+
+					if (accountWithUnread) {
+						accounts.selectAccount(accountWithUnread.id);
+					}
+
 					main.show();
 				});
 


### PR DESCRIPTION
## Summary
- When clicking the menubar icon, automatically switch to the first account that has unread emails before showing the window
- If multiple accounts have unread mail, activates the first one in the account list
- If no accounts have unread mail, shows the window normally without changing the selected account

## Test plan
- [x] Configure multiple accounts
- [x] Receive emails in a non-selected account
- [x] Click the menubar icon and verify it switches to the account with unread mail
- [x] Verify that if no accounts have unread mail, clicking the icon shows the currently selected account