### PR TITLE
Fix .desktop file

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,10 +153,7 @@
       ],
       "synopsis": "The Gmail experience you deserve",
       "description": "Tired of losing your inbox in browser tabs? Meru brings Gmail to your fingertips as a desktop app",
-      "category": "Network;Office",
-      "mimeTypes": [
-        "x-scheme-handler/mailto"
-      ]
+      "category": "Network;Office"
     },
     "win": {
       "verifyUpdateCodeSignature": false,


### PR DESCRIPTION
- Remove duplicate `mimeTypes` entry from `linux` config in `package.json`
- `protocols.schemes: ["meru", "mailto"]` already generates the correct `x-scheme-handler/mailto` and `x-scheme-handler/meru` entries - the explicit `linux.mimeTypes` caused electron-builder to emit duplicates

## Before
```
MimeType=x-scheme-handler/mailto;x-scheme-handler/meru;x-scheme-handler/mailto;x-scheme-handler/meru ;x-scheme-handler/mailto;
```

> warning: value for key "MimeType" contains "x-scheme-handler/mailto" more than once
> warning: value for key "MimeType" contains "x-scheme-handler/meru" more than once

## After
```
MimeType=x-scheme-handler/meru;x-scheme-handler/mailto;
```

No warnings from `desktop-file-validate`.