### PR TITLE
Add configurable notification time windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,5 +176,3 @@ dist
 
 # Meru
 build-js
-packages/**/*.js
-scripts/**/*.js

--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,5 @@ dist
 
 # Meru
 build-js
+packages/app/**/*.js
+scripts/**/*.js

--- a/.gitignore
+++ b/.gitignore
@@ -176,5 +176,5 @@ dist
 
 # Meru
 build-js
-packages/app/**/*.js
+packages/**/*.js
 scripts/**/*.js

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "ignorePatterns": []
+}

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,13 +1,7 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["typescript", "unicorn", "oxc"],
-  "categories": {
-    "correctness": "error"
-  },
+  "plugins": ["typescript"],
   "rules": {
     "typescript/no-non-null-assertion": "error"
-  },
-  "env": {
-    "builtin": true
   }
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["typescript", "unicorn", "oxc"],
+  "categories": {
+    "correctness": "error"
+  },
+  "rules": {
+    "typescript/no-non-null-assertion": "error"
+  },
+  "env": {
+    "builtin": true
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@
   ```
 
 - Add an empty line before `if` blocks when preceded by other statements.
-- Add empty lines around state updates (e.g. `setTimes(...)`) when they appear between other operations.
+- Add an empty line before `return` statements when preceded by other statements.
 
 ## Functions Inside Components
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@
 
 ## Dependencies
 
-- Always run `bun install --frozen-lockfile --ignore-scripts` before running any package.json scripts.
+- Always run `bun install --frozen-lockfile` before running any package.json scripts. This installs dependencies and runs postinstall scripts including the lefthook pre-commit hook.
 
 ## Linting
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,13 @@
 - Structure settings fields as: `Field` > `FieldLabel` + `FieldDescription` + control component.
 - Access config via `useConfig()` and persist changes via `useConfigMutation()`.
 - Use `toast.error()` for validation errors — never throw or console.error for user-facing feedback.
+- Always guard against unloaded config with an early return before accessing config values:
+
+  ```ts
+  if (!config) {
+    return;
+  }
+  ```
 
 ## Config Keys
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,14 @@
 
 - Always run `bun install --frozen-lockfile --ignore-scripts` before running any package.json scripts.
 
+## Linting
+
+- Never use `!` non-null assertions in TypeScript — enforced via `typescript/no-non-null-assertion` in `.oxlintrc.json`. Refactor the code to avoid them instead.
+
+## Pre-commit Hooks
+
+- Run `bun lefthook run pre-commit` before committing. This auto-formats staged files with oxfmt and auto-fixes lint errors with oxlint.
+
 ## Formatting Tool
 
 - Always run `bun fmt` after making code changes. It uses oxfmt to auto-format all files.
@@ -60,7 +68,6 @@
 ## Type Checking
 
 - Always run `bun types:ci` after making code changes to verify there are no type errors.
-- Never use `!` non-null assertions in TypeScript. Refactor the code to avoid them instead.
 
 ## General
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,15 +50,11 @@
 
 ## Dependencies
 
-- Always run `bun install --frozen-lockfile` before running any package.json scripts. This installs dependencies and runs postinstall scripts including the lefthook pre-commit hook.
+- Always run `bun install --frozen-lockfile` at the start of any work session to ensure dependencies are installed. This also runs postinstall scripts including the lefthook pre-commit hook.
 
 ## Linting
 
 - Never use `!` non-null assertions in TypeScript — enforced via `typescript/no-non-null-assertion` in `.oxlintrc.json`. Refactor the code to avoid them instead.
-
-## Pre-commit Hooks
-
-- Run `bun lefthook run pre-commit` before committing. This auto-formats staged files with oxfmt and auto-fixes lint errors with oxlint.
 
 ## Formatting Tool
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,11 +56,6 @@
 
 - Never use `!` non-null assertions in TypeScript — enforced via `typescript/no-non-null-assertion` in `.oxlintrc.json`. Refactor the code to avoid them instead.
 
-## Formatting Tool
-
-- Always run `bun fmt` after making code changes. It uses oxfmt to auto-format all files.
-- Run `bun fmt:check` to verify formatting without making changes.
-
 ## Type Checking
 
 - Always run `bun types:ci` after making code changes to verify there are no type errors.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,10 @@
 
 - Always run `bun install --frozen-lockfile` at the start of any work session to ensure dependencies are installed. This also runs postinstall scripts including the lefthook pre-commit hook.
 
+## TypeScript
+
+- Do not add explicit return types unless necessary — rely on inference.
+
 ## Linting
 
 - Never use `!` non-null assertions in TypeScript — enforced via `typescript/no-non-null-assertion` in `.oxlintrc.json`. Refactor the code to avoid them instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,10 @@
 
 - Follow the existing `"section.camelCase"` dot-notation pattern (e.g. `"notifications.times"`).
 
+## Dependencies
+
+- Always run `bun install --frozen-lockfile --ignore-scripts` before running any package.json scripts.
+
 ## Formatting Tool
 
 - Always run `bun fmt` after making code changes. It uses oxfmt to auto-format all files.
@@ -56,6 +60,7 @@
 ## Type Checking
 
 - Always run `bun types:ci` after making code changes to verify there are no type errors.
+- Never use `!` non-null assertions in TypeScript. Refactor the code to avoid them instead.
 
 ## General
 

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -55,6 +55,7 @@ export const config = new Store<Config>({
     "notifications.sound": "linen",
     "notifications.volume": 1,
     "notifications.downloadCompleted": true,
+    "notifications.times": [],
     "updates.autoCheck": true,
     "updates.showNotifications": true,
     "blocker.enabled": true,

--- a/packages/app/notifications.ts
+++ b/packages/app/notifications.ts
@@ -4,6 +4,23 @@ import { ipc } from "./ipc";
 import { licenseKey } from "./license-key";
 import { main } from "./main";
 
+function timeToMinutes(t: string) {
+  const [h, m] = t.split(":").map(Number);
+  return h * 60 + m;
+}
+
+function isWithinNotificationTimes(): boolean {
+  const times = config.get("notifications.times");
+  if (!times.length) return true;
+  const now = new Date();
+  const current = now.getHours() * 60 + now.getMinutes();
+  return times.some(({ start, end }) => {
+    const s = timeToMinutes(start);
+    const e = timeToMinutes(end);
+    return e > s ? current >= s && current < e : current >= s || current < e;
+  });
+}
+
 export function createNotification({
   click,
   action,
@@ -12,7 +29,7 @@ export function createNotification({
   click?: () => void;
   action?: (index: number) => void;
 }) {
-  if (!Notification.isSupported() || config.get("doNotDisturb.enabled")) {
+  if (!Notification.isSupported() || config.get("doNotDisturb.enabled") || !isWithinNotificationTimes()) {
     return;
   }
 

--- a/packages/app/notifications.ts
+++ b/packages/app/notifications.ts
@@ -4,12 +4,12 @@ import { ipc } from "./ipc";
 import { licenseKey } from "./license-key";
 import { main } from "./main";
 
-function timeToMinutes(time: string): number {
+function timeToMinutes(time: string) {
   const colonIndex = time.indexOf(":");
   return Number(time.slice(0, colonIndex)) * 60 + Number(time.slice(colonIndex + 1));
 }
 
-function isWithinNotificationTimes(): boolean {
+function isWithinNotificationTimes() {
   const times = config.get("notifications.times");
 
   if (!times.length) {

--- a/packages/app/notifications.ts
+++ b/packages/app/notifications.ts
@@ -4,20 +4,28 @@ import { ipc } from "./ipc";
 import { licenseKey } from "./license-key";
 import { main } from "./main";
 
-function timeToMinutes(t: string) {
-  const [h, m] = t.split(":").map(Number);
-  return h * 60 + m;
+function timeToMinutes(time: string) {
+  const [hours, minutes] = time.split(":").map(Number);
+  return hours * 60 + minutes;
 }
 
 function isWithinNotificationTimes(): boolean {
   const times = config.get("notifications.times");
-  if (!times.length) return true;
+
+  if (!times.length) {
+    return true;
+  }
+
   const now = new Date();
   const current = now.getHours() * 60 + now.getMinutes();
+
   return times.some(({ start, end }) => {
-    const s = timeToMinutes(start);
-    const e = timeToMinutes(end);
-    return e > s ? current >= s && current < e : current >= s || current < e;
+    const startMinutes = timeToMinutes(start);
+    const endMinutes = timeToMinutes(end);
+
+    return endMinutes > startMinutes
+      ? current >= startMinutes && current < endMinutes
+      : current >= startMinutes || current < endMinutes;
   });
 }
 

--- a/packages/app/notifications.ts
+++ b/packages/app/notifications.ts
@@ -4,9 +4,9 @@ import { ipc } from "./ipc";
 import { licenseKey } from "./license-key";
 import { main } from "./main";
 
-function timeToMinutes(time: string) {
-  const [hours, minutes] = time.split(":").map(Number);
-  return hours * 60 + minutes;
+function timeToMinutes(time: string): number {
+  const colonIndex = time.indexOf(":");
+  return Number(time.slice(0, colonIndex)) * 60 + Number(time.slice(colonIndex + 1));
 }
 
 function isWithinNotificationTimes(): boolean {
@@ -37,7 +37,11 @@ export function createNotification({
   click?: () => void;
   action?: (index: number) => void;
 }) {
-  if (!Notification.isSupported() || config.get("doNotDisturb.enabled") || !isWithinNotificationTimes()) {
+  if (
+    !Notification.isSupported() ||
+    config.get("doNotDisturb.enabled") ||
+    !isWithinNotificationTimes()
+  ) {
     return;
   }
 

--- a/packages/renderer/routes/settings/notifications.tsx
+++ b/packages/renderer/routes/settings/notifications.tsx
@@ -84,6 +84,7 @@ export function NotificationsSettings() {
     }
 
     setTimes(newTimes);
+
     configMutation.mutate({ "notifications.times": newTimes });
   }
 
@@ -102,7 +103,9 @@ export function NotificationsSettings() {
 
   function removeTime(id: string) {
     const newTimes = times.filter((t) => t.id !== id);
+
     setTimes(newTimes);
+
     configMutation.mutate({ "notifications.times": newTimes });
   }
 

--- a/packages/renderer/routes/settings/notifications.tsx
+++ b/packages/renderer/routes/settings/notifications.tsx
@@ -39,20 +39,16 @@ function timeToMinutes(time: string): number {
 }
 
 function hasOverlap(times: NotificationTime[]): boolean {
-  for (let i = 0; i < times.length; i++) {
-    for (let j = i + 1; j < times.length; j++) {
-      const aStart = timeToMinutes(times[i]!.start);
-      const aEnd = timeToMinutes(times[i]!.end);
-      const bStart = timeToMinutes(times[j]!.start);
-      const bEnd = timeToMinutes(times[j]!.end);
+  return times.some((timeA, index) =>
+    times.slice(index + 1).some((timeB) => {
+      const aStart = timeToMinutes(timeA.start);
+      const aEnd = timeToMinutes(timeA.end);
+      const bStart = timeToMinutes(timeB.start);
+      const bEnd = timeToMinutes(timeB.end);
 
-      if (aStart < bEnd && bStart < aEnd) {
-        return true;
-      }
-    }
-  }
-
-  return false;
+      return aStart < bEnd && bStart < aEnd;
+    }),
+  );
 }
 
 function minutesToTime(totalMinutes: number): string {

--- a/packages/renderer/routes/settings/notifications.tsx
+++ b/packages/renderer/routes/settings/notifications.tsx
@@ -145,6 +145,38 @@ export function NotificationsSettings() {
                     />
                   )}
                   <Field>
+                    <FieldLabel>Notification Times</FieldLabel>
+                    <FieldDescription>
+                      Configure time windows when notifications are active. Outside these windows,
+                      notifications will be silenced. Leave empty to always allow notifications.
+                    </FieldDescription>
+                    {times.map((time) => (
+                      <div key={time.id} className="flex items-center gap-2">
+                        <Input
+                          type="time"
+                          value={time.start}
+                          onChange={(event) => updateTime(time.id, "start", event.target.value)}
+                          className="appearance-none bg-background [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:appearance-none"
+                        />
+                        <span className="text-muted-foreground shrink-0 text-sm">to</span>
+                        <Input
+                          type="time"
+                          value={time.end}
+                          onChange={(event) => updateTime(time.id, "end", event.target.value)}
+                          className="appearance-none bg-background [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:appearance-none"
+                        />
+                        <Button variant="ghost" size="icon" onClick={() => removeTime(time.id)}>
+                          <X />
+                        </Button>
+                      </div>
+                    ))}
+                    <div>
+                      <Button variant="outline" onClick={addTime}>
+                        <Plus /> Add Time Window
+                      </Button>
+                    </div>
+                  </Field>
+                  <Field>
                     <FieldLabel>Test Notification</FieldLabel>
                     <FieldDescription>
                       Show a test notification to see how notifications will appear.
@@ -286,41 +318,6 @@ export function NotificationsSettings() {
                   )}
                 </>
               )}
-            </FieldGroup>
-          </FieldSet>
-          <FieldSeparator />
-          <FieldSet>
-            <FieldLabel>Notification Times</FieldLabel>
-            <FieldGroup>
-              <Field>
-                <FieldDescription>
-                  Configure time windows when notifications are active. Outside these windows,
-                  notifications will be silenced. Leave empty to always allow notifications.
-                </FieldDescription>
-              </Field>
-              {times.map((time) => (
-                <div key={time.id} className="flex items-center gap-2">
-                  <Input
-                    type="time"
-                    value={time.start}
-                    onChange={(e) => updateTime(time.id, "start", e.target.value)}
-                  />
-                  <span className="text-muted-foreground shrink-0 text-sm">to</span>
-                  <Input
-                    type="time"
-                    value={time.end}
-                    onChange={(e) => updateTime(time.id, "end", e.target.value)}
-                  />
-                  <Button variant="ghost" size="icon" onClick={() => removeTime(time.id)}>
-                    <X />
-                  </Button>
-                </div>
-              ))}
-              <div>
-                <Button variant="outline" onClick={addTime}>
-                  <Plus /> Add Time Window
-                </Button>
-              </div>
             </FieldGroup>
           </FieldSet>
         </FieldGroup>

--- a/packages/renderer/routes/settings/notifications.tsx
+++ b/packages/renderer/routes/settings/notifications.tsx
@@ -30,7 +30,6 @@ import { NOTIFICATION_SOUNDS, playNotificationSound } from "@/lib/notifications"
 import { useConfig, useConfigMutation } from "@meru/renderer-lib/react-query";
 import type { NotificationTime } from "@meru/shared/types";
 import { Plus, X } from "lucide-react";
-import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
 function timeToMinutes(time: string): number {
@@ -89,17 +88,11 @@ export function NotificationsSettings() {
 
   const isLicenseKeyValid = useIsLicenseKeyValid();
 
-  const [times, setTimes] = useState<NotificationTime[]>([]);
-
-  useEffect(() => {
-    if (config) {
-      setTimes(config["notifications.times"]);
-    }
-  }, [config]);
-
   if (!config) {
     return;
   }
+
+  const times = config["notifications.times"];
 
   const addTime = () => {
     const slot = findFreeSlot(times);
@@ -110,17 +103,12 @@ export function NotificationsSettings() {
     }
 
     const newEntry: NotificationTime = { id: crypto.randomUUID(), ...slot };
-    const newTimes = [...times, newEntry];
 
-    setTimes(newTimes);
-
-    configMutation.mutate({ "notifications.times": newTimes });
+    configMutation.mutate({ "notifications.times": [...times, newEntry] });
   };
 
   const updateTime = (id: string, field: "start" | "end", value: string) => {
     const newTimes = times.map((time) => (time.id === id ? { ...time, [field]: value } : time));
-
-    setTimes(newTimes);
 
     if (hasOverlap(newTimes)) {
       toast.error("Notification times overlap. Please adjust the time windows.");
@@ -131,11 +119,9 @@ export function NotificationsSettings() {
   };
 
   const removeTime = (id: string) => {
-    const newTimes = times.filter((time) => time.id !== id);
-
-    setTimes(newTimes);
-
-    configMutation.mutate({ "notifications.times": newTimes });
+    configMutation.mutate({
+      "notifications.times": times.filter((time) => time.id !== id),
+    });
   };
 
   return (

--- a/packages/renderer/routes/settings/notifications.tsx
+++ b/packages/renderer/routes/settings/notifications.tsx
@@ -33,18 +33,18 @@ import { Plus, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
-function timeToMinutes(time: string) {
-  const [hours, minutes] = time.split(":").map(Number);
-  return hours * 60 + minutes;
+function timeToMinutes(time: string): number {
+  const colonIndex = time.indexOf(":");
+  return Number(time.slice(0, colonIndex)) * 60 + Number(time.slice(colonIndex + 1));
 }
 
 function hasOverlap(times: NotificationTime[]): boolean {
   for (let i = 0; i < times.length; i++) {
     for (let j = i + 1; j < times.length; j++) {
-      const aStart = timeToMinutes(times[i].start);
-      const aEnd = timeToMinutes(times[i].end);
-      const bStart = timeToMinutes(times[j].start);
-      const bEnd = timeToMinutes(times[j].end);
+      const aStart = timeToMinutes(times[i]!.start);
+      const aEnd = timeToMinutes(times[i]!.end);
+      const bStart = timeToMinutes(times[j]!.start);
+      const bEnd = timeToMinutes(times[j]!.end);
 
       if (aStart < bEnd && bStart < aEnd) {
         return true;

--- a/packages/renderer/routes/settings/notifications.tsx
+++ b/packages/renderer/routes/settings/notifications.tsx
@@ -12,6 +12,7 @@ import {
   FieldSet,
   FieldTitle,
 } from "@meru/ui/components/field";
+import { Input } from "@meru/ui/components/input";
 import {
   Select,
   SelectContent,
@@ -27,7 +28,28 @@ import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/comp
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { NOTIFICATION_SOUNDS, playNotificationSound } from "@/lib/notifications";
 import { useConfig, useConfigMutation } from "@meru/renderer-lib/react-query";
+import type { NotificationTime } from "@meru/shared/types";
+import { Plus, X } from "lucide-react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
+
+function timeToMinutes(t: string) {
+  const [h, m] = t.split(":").map(Number);
+  return h * 60 + m;
+}
+
+function hasOverlap(times: NotificationTime[]): boolean {
+  for (let i = 0; i < times.length; i++) {
+    for (let j = i + 1; j < times.length; j++) {
+      const aS = timeToMinutes(times[i].start);
+      const aE = timeToMinutes(times[i].end);
+      const bS = timeToMinutes(times[j].start);
+      const bE = timeToMinutes(times[j].end);
+      if (aS < bE && bS < aE) return true;
+    }
+  }
+  return false;
+}
 
 export function NotificationsSettings() {
   const { config } = useConfig();
@@ -36,8 +58,43 @@ export function NotificationsSettings() {
 
   const isLicenseKeyValid = useIsLicenseKeyValid();
 
+  const [times, setTimes] = useState<NotificationTime[]>([]);
+
+  useEffect(() => {
+    if (config) {
+      setTimes(config["notifications.times"]);
+    }
+  }, [config]);
+
   if (!config) {
     return;
+  }
+
+  function addTime() {
+    const newEntry: NotificationTime = { id: crypto.randomUUID(), start: "09:00", end: "17:00" };
+    const newTimes = [...times, newEntry];
+    if (hasOverlap(newTimes)) {
+      toast.error("Notification times overlap. Please adjust existing windows first.");
+      return;
+    }
+    setTimes(newTimes);
+    configMutation.mutate({ "notifications.times": newTimes });
+  }
+
+  function updateTime(id: string, field: "start" | "end", value: string) {
+    const newTimes = times.map((t) => (t.id === id ? { ...t, [field]: value } : t));
+    setTimes(newTimes);
+    if (hasOverlap(newTimes)) {
+      toast.error("Notification times overlap. Please adjust the time windows.");
+      return;
+    }
+    configMutation.mutate({ "notifications.times": newTimes });
+  }
+
+  function removeTime(id: string) {
+    const newTimes = times.filter((t) => t.id !== id);
+    setTimes(newTimes);
+    configMutation.mutate({ "notifications.times": newTimes });
   }
 
   return (
@@ -217,6 +274,41 @@ export function NotificationsSettings() {
                   )}
                 </>
               )}
+            </FieldGroup>
+          </FieldSet>
+          <FieldSeparator />
+          <FieldSet>
+            <FieldLabel>Notification Times</FieldLabel>
+            <FieldGroup>
+              <Field>
+                <FieldDescription>
+                  Configure time windows when notifications are active. Outside these windows,
+                  notifications will be silenced. Leave empty to always allow notifications.
+                </FieldDescription>
+              </Field>
+              {times.map((time) => (
+                <div key={time.id} className="flex items-center gap-2">
+                  <Input
+                    type="time"
+                    value={time.start}
+                    onChange={(e) => updateTime(time.id, "start", e.target.value)}
+                  />
+                  <span className="text-muted-foreground shrink-0 text-sm">to</span>
+                  <Input
+                    type="time"
+                    value={time.end}
+                    onChange={(e) => updateTime(time.id, "end", e.target.value)}
+                  />
+                  <Button variant="ghost" size="icon" onClick={() => removeTime(time.id)}>
+                    <X />
+                  </Button>
+                </div>
+              ))}
+              <div>
+                <Button variant="outline" onClick={addTime}>
+                  <Plus /> Add Time Window
+                </Button>
+              </div>
             </FieldGroup>
           </FieldSet>
         </FieldGroup>

--- a/packages/renderer/routes/settings/notifications.tsx
+++ b/packages/renderer/routes/settings/notifications.tsx
@@ -32,12 +32,12 @@ import type { NotificationTime } from "@meru/shared/types";
 import { Plus, X } from "lucide-react";
 import { toast } from "sonner";
 
-function timeToMinutes(time: string): number {
+function timeToMinutes(time: string) {
   const colonIndex = time.indexOf(":");
   return Number(time.slice(0, colonIndex)) * 60 + Number(time.slice(colonIndex + 1));
 }
 
-function hasOverlap(times: NotificationTime[]): boolean {
+function hasOverlap(times: NotificationTime[]) {
   return times.some((timeA, index) =>
     times.slice(index + 1).some((timeB) => {
       const aStart = timeToMinutes(timeA.start);
@@ -50,13 +50,13 @@ function hasOverlap(times: NotificationTime[]): boolean {
   );
 }
 
-function minutesToTime(totalMinutes: number): string {
+function minutesToTime(totalMinutes: number) {
   const hours = Math.floor(totalMinutes / 60);
   const minutes = totalMinutes % 60;
   return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
 }
 
-function findFreeSlot(existingTimes: NotificationTime[]): { start: string; end: string } | null {
+function findFreeSlot(existingTimes: NotificationTime[]) {
   if (existingTimes.length === 0) {
     return { start: "09:00", end: "17:00" };
   }

--- a/packages/renderer/routes/settings/notifications.tsx
+++ b/packages/renderer/routes/settings/notifications.tsx
@@ -99,6 +99,7 @@ export function NotificationsSettings() {
 
     if (!slot) {
       toast.error("No free time slot available to add a new window.");
+
       return;
     }
 
@@ -112,6 +113,7 @@ export function NotificationsSettings() {
 
     if (hasOverlap(newTimes)) {
       toast.error("Notification times overlap. Please adjust the time windows.");
+
       return;
     }
 

--- a/packages/renderer/routes/settings/notifications.tsx
+++ b/packages/renderer/routes/settings/notifications.tsx
@@ -55,6 +55,37 @@ function hasOverlap(times: NotificationTime[]): boolean {
   return false;
 }
 
+function minutesToTime(totalMinutes: number): string {
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
+}
+
+function findFreeSlot(existingTimes: NotificationTime[]): { start: string; end: string } | null {
+  if (existingTimes.length === 0) {
+    return { start: "09:00", end: "17:00" };
+  }
+
+  for (let hour = 0; hour < 24; hour++) {
+    const startMinutes = hour * 60;
+    const endMinutes = startMinutes + 60;
+
+    if (endMinutes > 24 * 60) {
+      break;
+    }
+
+    const start = minutesToTime(startMinutes);
+    const end = minutesToTime(endMinutes);
+    const candidate: NotificationTime = { id: "", start, end };
+
+    if (!hasOverlap([...existingTimes, candidate])) {
+      return { start, end };
+    }
+  }
+
+  return null;
+}
+
 export function NotificationsSettings() {
   const { config } = useConfig();
 
@@ -74,22 +105,24 @@ export function NotificationsSettings() {
     return;
   }
 
-  function addTime() {
-    const newEntry: NotificationTime = { id: crypto.randomUUID(), start: "09:00", end: "17:00" };
-    const newTimes = [...times, newEntry];
+  const addTime = () => {
+    const slot = findFreeSlot(times);
 
-    if (hasOverlap(newTimes)) {
-      toast.error("Notification times overlap. Please adjust existing windows first.");
+    if (!slot) {
+      toast.error("No free time slot available to add a new window.");
       return;
     }
+
+    const newEntry: NotificationTime = { id: crypto.randomUUID(), ...slot };
+    const newTimes = [...times, newEntry];
 
     setTimes(newTimes);
 
     configMutation.mutate({ "notifications.times": newTimes });
-  }
+  };
 
-  function updateTime(id: string, field: "start" | "end", value: string) {
-    const newTimes = times.map((t) => (t.id === id ? { ...t, [field]: value } : t));
+  const updateTime = (id: string, field: "start" | "end", value: string) => {
+    const newTimes = times.map((time) => (time.id === id ? { ...time, [field]: value } : time));
 
     setTimes(newTimes);
 
@@ -99,15 +132,15 @@ export function NotificationsSettings() {
     }
 
     configMutation.mutate({ "notifications.times": newTimes });
-  }
+  };
 
-  function removeTime(id: string) {
-    const newTimes = times.filter((t) => t.id !== id);
+  const removeTime = (id: string) => {
+    const newTimes = times.filter((time) => time.id !== id);
 
     setTimes(newTimes);
 
     configMutation.mutate({ "notifications.times": newTimes });
-  }
+  };
 
   return (
     <Settings>

--- a/packages/renderer/routes/settings/notifications.tsx
+++ b/packages/renderer/routes/settings/notifications.tsx
@@ -33,21 +33,25 @@ import { Plus, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
-function timeToMinutes(t: string) {
-  const [h, m] = t.split(":").map(Number);
-  return h * 60 + m;
+function timeToMinutes(time: string) {
+  const [hours, minutes] = time.split(":").map(Number);
+  return hours * 60 + minutes;
 }
 
 function hasOverlap(times: NotificationTime[]): boolean {
   for (let i = 0; i < times.length; i++) {
     for (let j = i + 1; j < times.length; j++) {
-      const aS = timeToMinutes(times[i].start);
-      const aE = timeToMinutes(times[i].end);
-      const bS = timeToMinutes(times[j].start);
-      const bE = timeToMinutes(times[j].end);
-      if (aS < bE && bS < aE) return true;
+      const aStart = timeToMinutes(times[i].start);
+      const aEnd = timeToMinutes(times[i].end);
+      const bStart = timeToMinutes(times[j].start);
+      const bEnd = timeToMinutes(times[j].end);
+
+      if (aStart < bEnd && bStart < aEnd) {
+        return true;
+      }
     }
   }
+
   return false;
 }
 

--- a/packages/renderer/routes/settings/notifications.tsx
+++ b/packages/renderer/routes/settings/notifications.tsx
@@ -77,21 +77,26 @@ export function NotificationsSettings() {
   function addTime() {
     const newEntry: NotificationTime = { id: crypto.randomUUID(), start: "09:00", end: "17:00" };
     const newTimes = [...times, newEntry];
+
     if (hasOverlap(newTimes)) {
       toast.error("Notification times overlap. Please adjust existing windows first.");
       return;
     }
+
     setTimes(newTimes);
     configMutation.mutate({ "notifications.times": newTimes });
   }
 
   function updateTime(id: string, field: "start" | "end", value: string) {
     const newTimes = times.map((t) => (t.id === id ? { ...t, [field]: value } : t));
+
     setTimes(newTimes);
+
     if (hasOverlap(newTimes)) {
       toast.error("Notification times overlap. Please adjust the time windows.");
       return;
     }
+
     configMutation.mutate({ "notifications.times": newTimes });
   }
 

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -25,6 +25,12 @@ export type DownloadItem = {
 
 export type NotificationSound = "breeze" | "chime" | "duet" | "knock" | "linen";
 
+export type NotificationTime = {
+  id: string;
+  start: string; // "HH:mm" 24-hour
+  end: string; // "HH:mm" 24-hour
+};
+
 export const googleAppsPinnedApps = {
   calendar: "Calendar",
   chat: "Chat",
@@ -86,6 +92,7 @@ export type Config = {
   "notifications.sound": "system" | NotificationSound;
   "notifications.volume": number;
   "notifications.downloadCompleted": boolean;
+  "notifications.times": NotificationTime[];
   "updates.autoCheck": boolean;
   "updates.showNotifications": boolean;
   "blocker.enabled": boolean;


### PR DESCRIPTION
## Summary

- Adds a "Notification Times" section to notification settings where users can define daily time windows when notifications are active
- Outside configured windows, notifications are silenced; an empty list means always allow
- Multiple non-overlapping windows are supported — overlap is detected in both the UI (toast error) and before persisting
- Overnight ranges (e.g. 22:00–06:00) are handled correctly
- Time inputs use `input[type="time"]` which auto-adapts to the OS locale (12h/24h) via Chromium
- Times stored internally as `"HH:mm"` 24-hour strings

## Test plan

- [ ] Add a time window (09:00–17:00) → persists on app restart
- [ ] Add a second non-overlapping window (19:00–21:00) → both saved
- [ ] Edit a window to overlap another → toast error appears, overlap not persisted
- [ ] Delete a window → removed immediately
- [ ] Empty times list → notifications fire normally
- [ ] Current local time outside all windows → notifications are silenced