### PR TITLE
run CI on pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "*"
+  pull_request:
 
 jobs:
   ci:


### PR DESCRIPTION
## Summary

- Added `pull_request:` trigger to the main GitHub Actions workflow so CI runs on pull requests in addition to pushes.

## What changed

`.github/workflows/main.yml` now includes a `pull_request:` event trigger alongside the existing `push` trigger.