### PR TITLE
Require Meru Pro license for notification times

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,15 @@
 # Meru – Claude Code Guidelines
 
+## FIRST STEP — Required Before Any Work
+
+**Run this before doing anything else in a session, no exceptions:**
+
+```sh
+bun install --frozen-lockfile
+```
+
+This installs dependencies and runs postinstall scripts (including the lefthook pre-commit hook). Skipping this causes missing packages, broken type checks, and unwanted build artifacts.
+
 ## Variable Naming
 
 - Always use descriptive names. Never use single-letter or abbreviated names anywhere — including callback parameters.
@@ -54,10 +64,6 @@
 ## Config Keys
 
 - Follow the existing `"section.camelCase"` dot-notation pattern (e.g. `"notifications.times"`).
-
-## Dependencies
-
-- Always run `bun install --frozen-lockfile` at the start of any work session to ensure dependencies are installed. This also runs postinstall scripts including the lefthook pre-commit hook.
 
 ## TypeScript
 

--- a/packages/app/notifications.ts
+++ b/packages/app/notifications.ts
@@ -10,6 +10,10 @@ function timeToMinutes(time: string) {
 }
 
 function isWithinNotificationTimes() {
+  if (!licenseKey.isValid) {
+    return true;
+  }
+
   const times = config.get("notifications.times");
 
   if (!times.length) {

--- a/packages/renderer/routes/settings/notifications.tsx
+++ b/packages/renderer/routes/settings/notifications.tsx
@@ -162,7 +162,10 @@ export function NotificationsSettings() {
                     />
                   )}
                   <Field>
-                    <FieldLabel>Notification Times</FieldLabel>
+                    <FieldLabel className="flex items-center gap-2">
+                      Notification Times
+                      {!isLicenseKeyValid && <Badge variant="secondary">Meru Pro Required</Badge>}
+                    </FieldLabel>
                     <FieldDescription>
                       Configure time windows when notifications are active. Outside these windows,
                       notifications will be silenced. Leave empty to always allow notifications.
@@ -174,6 +177,7 @@ export function NotificationsSettings() {
                           value={time.start}
                           onChange={(event) => updateTime(time.id, "start", event.target.value)}
                           className="appearance-none bg-background [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:appearance-none"
+                          disabled={!isLicenseKeyValid}
                         />
                         <span className="text-muted-foreground shrink-0 text-sm">to</span>
                         <Input
@@ -181,14 +185,20 @@ export function NotificationsSettings() {
                           value={time.end}
                           onChange={(event) => updateTime(time.id, "end", event.target.value)}
                           className="appearance-none bg-background [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:appearance-none"
+                          disabled={!isLicenseKeyValid}
                         />
-                        <Button variant="ghost" size="icon" onClick={() => removeTime(time.id)}>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => removeTime(time.id)}
+                          disabled={!isLicenseKeyValid}
+                        >
                           <X />
                         </Button>
                       </div>
                     ))}
                     <div>
-                      <Button variant="outline" onClick={addTime}>
+                      <Button variant="outline" onClick={addTime} disabled={!isLicenseKeyValid}>
                         <Plus /> Add Time Window
                       </Button>
                     </div>


### PR DESCRIPTION
## Summary

- Adds "Meru Pro Required" badge to the Notification Times field label when no valid license is active
- Disables all time inputs, remove buttons, and the "Add Time Window" button for unlicensed users
- Moves `bun install --frozen-lockfile` to the top of CLAUDE.md as a mandatory first step with a clear heading and explanation

## Test plan

- [ ] With no license key: verify "Meru Pro Required" badge appears on the Notification Times label and all controls are disabled
- [ ] With a valid license key or active trial: verify badge is hidden and all controls are interactive
- [ ] Verify the field matches the style of other license-gated fields (e.g. Sound, Google Apps)