### PR TITLE
add unified inbox settings with an enabled toggle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,15 @@ This installs dependencies and runs postinstall scripts (including the lefthook 
 ## Config Keys
 
 - Follow the existing `"section.camelCase"` dot-notation pattern (e.g. `"notifications.times"`).
+- When combining a global config check with more specific conditions (e.g. per-account flags, counts, or local state), always check the global setting first so it short-circuits the rest:
+
+  ```ts
+  // correct
+  if (config.get("unifiedInbox.enabled") && accounts.length > 1) { ... }
+
+  // wrong
+  if (accounts.length > 1 && config.get("unifiedInbox.enabled")) { ... }
+  ```
 
 ## TypeScript
 

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -99,6 +99,7 @@ export const config = new Store<Config>({
     "doNotDisturb.duration": null,
     "doNotDisturb.until": null,
     "unifiedInbox.enabled": true,
+    "unifiedInbox.showSenderIcons": true,
     "unifiedInbox.rowsPerPage": 10,
   },
   migrations: {

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -98,6 +98,7 @@ export const config = new Store<Config>({
     "doNotDisturb.enabled": false,
     "doNotDisturb.duration": null,
     "doNotDisturb.until": null,
+    "unifiedInbox.enabled": true,
     "unifiedInbox.rowsPerPage": 10,
   },
   migrations: {

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -389,7 +389,7 @@ export class Gmail extends GoogleApp {
         }
       }
 
-      if (config.get("unifiedInbox.enabled") && this.unifiedInboxEnabled) {
+      if (licenseKey.isValid && config.get("unifiedInbox.enabled") && this.unifiedInboxEnabled) {
         this.store.setState({ unreadInbox });
       }
 
@@ -607,7 +607,7 @@ export class Gmail extends GoogleApp {
       );
     }
 
-    if (config.get("unifiedInbox.enabled") && this.unifiedInboxEnabled) {
+    if (licenseKey.isValid && config.get("unifiedInbox.enabled") && this.unifiedInboxEnabled) {
       this.store.subscribe(
         (state) => state.unreadInbox,
         () => {

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -389,7 +389,7 @@ export class Gmail extends GoogleApp {
         }
       }
 
-      if (this.unifiedInboxEnabled) {
+      if (this.unifiedInboxEnabled && config.get("unifiedInbox.enabled")) {
         this.store.setState({ unreadInbox });
       }
 
@@ -607,7 +607,7 @@ export class Gmail extends GoogleApp {
       );
     }
 
-    if (this.unifiedInboxEnabled) {
+    if (this.unifiedInboxEnabled && config.get("unifiedInbox.enabled")) {
       this.store.subscribe(
         (state) => state.unreadInbox,
         () => {

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -389,7 +389,7 @@ export class Gmail extends GoogleApp {
         }
       }
 
-      if (this.unifiedInboxEnabled && config.get("unifiedInbox.enabled")) {
+      if (config.get("unifiedInbox.enabled") && this.unifiedInboxEnabled) {
         this.store.setState({ unreadInbox });
       }
 
@@ -607,7 +607,7 @@ export class Gmail extends GoogleApp {
       );
     }
 
-    if (this.unifiedInboxEnabled && config.get("unifiedInbox.enabled")) {
+    if (config.get("unifiedInbox.enabled") && this.unifiedInboxEnabled) {
       this.store.subscribe(
         (state) => state.unreadInbox,
         () => {

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -332,7 +332,8 @@ export class AppMenu {
         submenu: [
           {
             label: "Unified Inbox",
-            enabled: config.get("unifiedInbox.enabled") && allAccounts.length > 1,
+            enabled:
+              licenseKey.isValid && config.get("unifiedInbox.enabled") && allAccounts.length > 1,
             accelerator: "CommandOrControl+Shift+I",
             click: () => {
               main.navigate("/unified-inbox");

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -332,7 +332,7 @@ export class AppMenu {
         submenu: [
           {
             label: "Unified Inbox",
-            enabled: allAccounts.length > 1 && config.get("unifiedInbox.enabled"),
+            enabled: config.get("unifiedInbox.enabled") && allAccounts.length > 1,
             accelerator: "CommandOrControl+Shift+I",
             click: () => {
               main.navigate("/unified-inbox");

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -332,7 +332,7 @@ export class AppMenu {
         submenu: [
           {
             label: "Unified Inbox",
-            enabled: allAccounts.length > 1,
+            enabled: allAccounts.length > 1 && config.get("unifiedInbox.enabled"),
             accelerator: "CommandOrControl+Shift+I",
             click: () => {
               main.navigate("/unified-inbox");

--- a/packages/renderer/components/app-sidebar.tsx
+++ b/packages/renderer/components/app-sidebar.tsx
@@ -15,6 +15,7 @@ import { LicenseSettings } from "@/routes/settings/license";
 import { NotificationsSettings } from "@/routes/settings/notifications";
 import { PhishingProtectionSettings } from "@/routes/settings/phishing-protection";
 import { SavedSearchesSettings } from "@/routes/settings/saved-searches";
+import { UnifiedInboxSettings } from "@/routes/settings/unified-inbox";
 import { UpdatesSettings } from "@/routes/settings/updates";
 import { VerificationCodesSettings } from "@/routes/settings/verification-codes";
 import { VersionHistorySettings } from "@/routes/settings/version-history";
@@ -69,6 +70,11 @@ export const sidebarNavItems: SidebarNavItemProps[] = [
     label: "Saved Searches",
     path: "/settings/saved-searches",
     component: SavedSearchesSettings,
+  },
+  {
+    label: "Unified Inbox",
+    path: "/settings/unified-inbox",
+    component: UnifiedInboxSettings,
   },
   {
     label: "Updates",

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -467,7 +467,7 @@ export function AppTitlebar() {
           >
             <ArrowRightIcon />
           </Button>
-          {accounts.length > 1 && config["unifiedInbox.enabled"] && (
+          {config["unifiedInbox.enabled"] && accounts.length > 1 && (
             <Button
               variant={matchUnifiedInboxRoute ? "secondary" : "ghost"}
               size="icon"

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -479,7 +479,7 @@ export function AppTitlebar() {
 
                 setIsGmailSavedSearchesOpen(false);
               }}
-              title="All Unread Inboxes"
+              title="Unified Inbox"
             >
               <InboxIcon />
             </Button>

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -467,7 +467,7 @@ export function AppTitlebar() {
           >
             <ArrowRightIcon />
           </Button>
-          {config["unifiedInbox.enabled"] && accounts.length > 1 && (
+          {isLicenseKeyValid && config["unifiedInbox.enabled"] && accounts.length > 1 && (
             <Button
               variant={matchUnifiedInboxRoute ? "secondary" : "ghost"}
               size="icon"

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -467,7 +467,7 @@ export function AppTitlebar() {
           >
             <ArrowRightIcon />
           </Button>
-          {accounts.length > 1 && (
+          {accounts.length > 1 && config["unifiedInbox.enabled"] && (
             <Button
               variant={matchUnifiedInboxRoute ? "secondary" : "ghost"}
               size="icon"

--- a/packages/renderer/routes/settings/unified-inbox.tsx
+++ b/packages/renderer/routes/settings/unified-inbox.tsx
@@ -21,7 +21,7 @@ export function UnifiedInboxSettings() {
           />
           <ConfigSwitchField
             label="Show Sender Icons"
-            description="Display sender avatars next to each message in the unified inbox."
+            description="Show sender icons next to the senders in the unified inbox."
             configKey="unifiedInbox.showSenderIcons"
             licenseKeyRequired
           />

--- a/packages/renderer/routes/settings/unified-inbox.tsx
+++ b/packages/renderer/routes/settings/unified-inbox.tsx
@@ -12,7 +12,7 @@ export function UnifiedInboxSettings() {
         <FieldGroup>
           <ConfigSwitchField
             label="Enabled"
-            description="Combine unread messages from all accounts into one inbox, accessible from the toolbar when multiple accounts are connected."
+            description="Show all unread messages from every account in a single unified inbox."
             configKey="unifiedInbox.enabled"
             restartRequired
           />

--- a/packages/renderer/routes/settings/unified-inbox.tsx
+++ b/packages/renderer/routes/settings/unified-inbox.tsx
@@ -19,6 +19,12 @@ export function UnifiedInboxSettings() {
             licenseKeyRequired
             restartRequired
           />
+          <ConfigSwitchField
+            label="Show Sender Icons"
+            description="Display sender avatars next to each message in the unified inbox."
+            configKey="unifiedInbox.showSenderIcons"
+            licenseKeyRequired
+          />
         </FieldGroup>
       </SettingsContent>
     </Settings>

--- a/packages/renderer/routes/settings/unified-inbox.tsx
+++ b/packages/renderer/routes/settings/unified-inbox.tsx
@@ -1,0 +1,23 @@
+import { FieldGroup } from "@meru/ui/components/field";
+import { ConfigSwitchField } from "@/components/config-switch-field";
+import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
+
+export function UnifiedInboxSettings() {
+  return (
+    <Settings>
+      <SettingsHeader>
+        <SettingsTitle>Unified Inbox</SettingsTitle>
+      </SettingsHeader>
+      <SettingsContent>
+        <FieldGroup>
+          <ConfigSwitchField
+            label="Enabled"
+            description="Show all unread messages from every account in a single unified inbox."
+            configKey="unifiedInbox.enabled"
+            restartRequired
+          />
+        </FieldGroup>
+      </SettingsContent>
+    </Settings>
+  );
+}

--- a/packages/renderer/routes/settings/unified-inbox.tsx
+++ b/packages/renderer/routes/settings/unified-inbox.tsx
@@ -12,7 +12,7 @@ export function UnifiedInboxSettings() {
         <FieldGroup>
           <ConfigSwitchField
             label="Enabled"
-            description="Show all unread messages from every account in a single unified inbox."
+            description="Combine unread messages from all accounts into one inbox, accessible from the toolbar when multiple accounts are connected."
             configKey="unifiedInbox.enabled"
             restartRequired
           />

--- a/packages/renderer/routes/settings/unified-inbox.tsx
+++ b/packages/renderer/routes/settings/unified-inbox.tsx
@@ -1,5 +1,6 @@
 import { FieldGroup } from "@meru/ui/components/field";
 import { ConfigSwitchField } from "@/components/config-switch-field";
+import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
 import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
 
 export function UnifiedInboxSettings() {
@@ -9,11 +10,13 @@ export function UnifiedInboxSettings() {
         <SettingsTitle>Unified Inbox</SettingsTitle>
       </SettingsHeader>
       <SettingsContent>
+        <LicenseKeyRequiredBanner />
         <FieldGroup>
           <ConfigSwitchField
             label="Enabled"
             description="Show all unread messages from every account in a single unified inbox."
             configKey="unifiedInbox.enabled"
+            licenseKeyRequired
             restartRequired
           />
         </FieldGroup>

--- a/packages/renderer/routes/unified-inbox.tsx
+++ b/packages/renderer/routes/unified-inbox.tsx
@@ -20,7 +20,7 @@ import {
   ChevronsRightIcon,
   InboxIcon,
 } from "lucide-react";
-import { Fragment, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import {
   type PaginationState,
   createColumnHelper,
@@ -42,7 +42,7 @@ import {
 
 const columnHelper = createColumnHelper<UnifiedInboxMessage>();
 
-const columns = [
+const createColumns = ({ showSenderIcons }: { showSenderIcons: boolean }) => [
   columnHelper.accessor("account.label", {
     cell: (props) => (
       <div className="w-20">
@@ -71,24 +71,26 @@ const columns = [
             .map(({ name, email }) => `${name} <${email}>`)
             .join(", ")}
         >
-          <AvatarGroup>
-            <Avatar className="size-4">
-              {domain && <AvatarImage src={getGoogleDomainFaviconUrl(domain, 32)} />}
-              <AvatarFallback />
-            </Avatar>
-            {props.row.original.contributors.slice(0, 2).map((contributor) => {
-              const contributorDomain = contributor.email.split("@")[1];
+          {showSenderIcons && (
+            <AvatarGroup>
+              <Avatar className="size-4">
+                {domain && <AvatarImage src={getGoogleDomainFaviconUrl(domain, 32)} />}
+                <AvatarFallback />
+              </Avatar>
+              {props.row.original.contributors.slice(0, 2).map((contributor) => {
+                const contributorDomain = contributor.email.split("@")[1];
 
-              return (
-                <Avatar key={contributor.email} className="size-4">
-                  {contributorDomain && (
-                    <AvatarImage src={getGoogleDomainFaviconUrl(contributorDomain, 32)} />
-                  )}
-                  <AvatarFallback />
-                </Avatar>
-              );
-            })}
-          </AvatarGroup>
+                return (
+                  <Avatar key={contributor.email} className="size-4">
+                    {contributorDomain && (
+                      <AvatarImage src={getGoogleDomainFaviconUrl(contributorDomain, 32)} />
+                    )}
+                    <AvatarFallback />
+                  </Avatar>
+                );
+              })}
+            </AvatarGroup>
+          )}
           <div className="truncate">
             {props.row.original.contributors.length === 0
               ? props.row.original.author.name
@@ -150,14 +152,18 @@ const columns = [
 function UnifiedInboxTable({
   messages,
   rowsPerPage,
+  showSenderIcons,
 }: {
   messages: UnifiedInboxMessage[];
   rowsPerPage: number;
+  showSenderIcons: boolean;
 }) {
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: rowsPerPage,
   });
+
+  const columns = useMemo(() => createColumns({ showSenderIcons }), [showSenderIcons]);
 
   const table = useReactTable({
     data: messages,
@@ -296,6 +302,7 @@ export function UnifiedInbox() {
       <UnifiedInboxTable
         messages={unifiedInbox.messages}
         rowsPerPage={config["unifiedInbox.rowsPerPage"]}
+        showSenderIcons={config["unifiedInbox.showSenderIcons"]}
       />
     );
   };

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -141,6 +141,7 @@ export type Config = {
   "doNotDisturb.enabled": boolean;
   "doNotDisturb.duration": string | null;
   "doNotDisturb.until": number | null;
+  "unifiedInbox.enabled": boolean;
   "unifiedInbox.rowsPerPage": number;
 };
 

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -142,6 +142,7 @@ export type Config = {
   "doNotDisturb.duration": string | null;
   "doNotDisturb.until": number | null;
   "unifiedInbox.enabled": boolean;
+  "unifiedInbox.showSenderIcons": boolean;
   "unifiedInbox.rowsPerPage": number;
 };
 


### PR DESCRIPTION
Adds a new "unifiedInbox.enabled" config (defaults to true) with a
dedicated settings page. The app now checks this flag when populating
the unified inbox store and menu item, and the renderer hides the
titlebar button when disabled.