### PR TITLE
Add ability to exclude Google Apps from opening in app

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -87,6 +87,7 @@ export const config = new Store<Config>({
     "window.restrictMinimumSize": true,
     "trial.expired": false,
     "googleApps.openInApp": true,
+    "googleApps.openInAppExcludedApps": [],
     "googleApps.openAppsInNewWindow": false,
     "googleApps.pinnedApps": [],
     "googleApps.showAccountColor": true,

--- a/packages/app/google-app.ts
+++ b/packages/app/google-app.ts
@@ -7,8 +7,8 @@ import {
   GMAIL_URL,
   isGmailComposeWindowUrl,
 } from "@meru/shared/gmail";
-import { googleAppsPinnedApps } from "@meru/shared/types";
-import type { GoogleAppsPinnedApp } from "@meru/shared/types";
+import { supportedGoogleApps } from "@meru/shared/types";
+import type { SupportedGoogleApp } from "@meru/shared/types";
 import {
   BrowserWindow,
   dialog,
@@ -33,8 +33,11 @@ const WINDOW_OPEN_URL_WHITELIST = [
   /googleusercontent\.com\/viewer\/secure\/pdf/, // Print PDF
 ];
 
-const SUPPORTED_GOOGLE_APPS_URL_REGEXP =
-  /(calendar|docs|sheets|slides|drive(\.usercontent)?|meet|contacts|voice|gemini|chat|forms|sites|keep|tasks|groups|myaccount|classroom|notebooklm)\.google\.com/;
+const SUPPORTED_GOOGLE_APPS_URL_REGEXP = new RegExp(
+  `(${Object.keys(supportedGoogleApps)
+    .map((app) => (app === "drive" ? "drive(\\.usercontent)?" : app))
+    .join("|")})\\.google\\.com`,
+);
 
 const WINDOW_OPEN_DOWNLOAD_URL_WHITELIST = [/chat\.google\.com\/u\/\d\/api\/get_attachment_url/];
 
@@ -277,10 +280,10 @@ export class GoogleApp {
         config.get("googleApps.openInApp") &&
         licenseKey.isValid &&
         (!matchedGoogleApp ||
-          !Object.hasOwn(googleAppsPinnedApps, matchedGoogleApp) ||
+          !Object.hasOwn(supportedGoogleApps, matchedGoogleApp) ||
           !config
             .get("googleApps.openInAppExcludedApps")
-            .includes(matchedGoogleApp as GoogleAppsPinnedApp));
+            .includes(matchedGoogleApp as SupportedGoogleApp));
 
       if (
         (url.startsWith(GMAIL_URL) ||

--- a/packages/app/google-app.ts
+++ b/packages/app/google-app.ts
@@ -33,10 +33,10 @@ const WINDOW_OPEN_URL_WHITELIST = [
   /googleusercontent\.com\/viewer\/secure\/pdf/, // Print PDF
 ];
 
+// `drive` also serves content under `drive.usercontent.google.com`, which should be matched but
+// captured as `drive`.
 const SUPPORTED_GOOGLE_APPS_URL_REGEXP = new RegExp(
-  `(${Object.keys(supportedGoogleApps)
-    .map((app) => (app === "drive" ? "drive(?:\\.usercontent)?" : app))
-    .join("|")})\\.google\\.com`,
+  `(${Object.keys(supportedGoogleApps).join("|")})(?:\\.usercontent)?\\.google\\.com`,
 );
 
 const WINDOW_OPEN_DOWNLOAD_URL_WHITELIST = [/chat\.google\.com\/u\/\d\/api\/get_attachment_url/];

--- a/packages/app/google-app.ts
+++ b/packages/app/google-app.ts
@@ -34,7 +34,9 @@ const WINDOW_OPEN_URL_WHITELIST = [
 ];
 
 const SUPPORTED_GOOGLE_APPS_URL_REGEXP = new RegExp(
-  `(${Object.keys(supportedGoogleApps).join("|")})(?:\\.usercontent)?\\.google\\.com`,
+  `(${Object.keys(supportedGoogleApps)
+    .map((app) => (app === "drive" ? "drive(?:\\.usercontent)?" : app))
+    .join("|")})\\.google\\.com`,
 );
 
 const WINDOW_OPEN_DOWNLOAD_URL_WHITELIST = [/chat\.google\.com\/u\/\d\/api\/get_attachment_url/];
@@ -274,9 +276,9 @@ export class GoogleApp {
         | undefined;
 
       const isGoogleAppEnabledToOpenInApp =
+        licenseKey.isValid &&
         matchedSupportedGoogleApp &&
         config.get("googleApps.openInApp") &&
-        licenseKey.isValid &&
         !config.get("googleApps.openInAppExcludedApps").includes(matchedSupportedGoogleApp);
 
       if (

--- a/packages/app/google-app.ts
+++ b/packages/app/google-app.ts
@@ -33,8 +33,6 @@ const WINDOW_OPEN_URL_WHITELIST = [
   /googleusercontent\.com\/viewer\/secure\/pdf/, // Print PDF
 ];
 
-// `drive` also serves content under `drive.usercontent.google.com`, which should be matched but
-// captured as `drive`.
 const SUPPORTED_GOOGLE_APPS_URL_REGEXP = new RegExp(
   `(${Object.keys(supportedGoogleApps).join("|")})(?:\\.usercontent)?\\.google\\.com`,
 );

--- a/packages/app/google-app.ts
+++ b/packages/app/google-app.ts
@@ -7,6 +7,8 @@ import {
   GMAIL_URL,
   isGmailComposeWindowUrl,
 } from "@meru/shared/gmail";
+import { googleAppsPinnedApps } from "@meru/shared/types";
+import type { GoogleAppsPinnedApp } from "@meru/shared/types";
 import {
   BrowserWindow,
   dialog,
@@ -268,10 +270,22 @@ export class GoogleApp {
 
       const supportedGoogleAppMatch = url.match(SUPPORTED_GOOGLE_APPS_URL_REGEXP);
 
+      const matchedGoogleApp = supportedGoogleAppMatch?.[1];
+
+      const isGoogleAppEnabledToOpenInApp =
+        supportedGoogleAppMatch &&
+        config.get("googleApps.openInApp") &&
+        licenseKey.isValid &&
+        (!matchedGoogleApp ||
+          !Object.hasOwn(googleAppsPinnedApps, matchedGoogleApp) ||
+          !config
+            .get("googleApps.openInAppExcludedApps")
+            .includes(matchedGoogleApp as GoogleAppsPinnedApp));
+
       if (
         (url.startsWith(GMAIL_URL) ||
           WINDOW_OPEN_URL_WHITELIST.some((regex) => regex.test(url)) ||
-          (supportedGoogleAppMatch && config.get("googleApps.openInApp") && licenseKey.isValid)) &&
+          isGoogleAppEnabledToOpenInApp) &&
         disposition !== "background-tab"
       ) {
         if (supportedGoogleAppMatch) {

--- a/packages/app/google-app.ts
+++ b/packages/app/google-app.ts
@@ -271,19 +271,16 @@ export class GoogleApp {
         };
       }
 
-      const supportedGoogleAppMatch = url.match(SUPPORTED_GOOGLE_APPS_URL_REGEXP);
-
-      const matchedGoogleApp = supportedGoogleAppMatch?.[1];
+      const matchedSupportedGoogleApp = url.match(SUPPORTED_GOOGLE_APPS_URL_REGEXP)?.[1];
 
       const isGoogleAppEnabledToOpenInApp =
-        supportedGoogleAppMatch &&
+        matchedSupportedGoogleApp &&
         config.get("googleApps.openInApp") &&
         licenseKey.isValid &&
-        (!matchedGoogleApp ||
-          !Object.hasOwn(supportedGoogleApps, matchedGoogleApp) ||
+        (!Object.hasOwn(supportedGoogleApps, matchedSupportedGoogleApp) ||
           !config
             .get("googleApps.openInAppExcludedApps")
-            .includes(matchedGoogleApp as SupportedGoogleApp));
+            .includes(matchedSupportedGoogleApp as SupportedGoogleApp));
 
       if (
         (url.startsWith(GMAIL_URL) ||
@@ -291,7 +288,7 @@ export class GoogleApp {
           isGoogleAppEnabledToOpenInApp) &&
         disposition !== "background-tab"
       ) {
-        if (supportedGoogleAppMatch) {
+        if (matchedSupportedGoogleApp) {
           const account = accounts.getAccount(this.accountId);
 
           if (!config.get("googleApps.openAppsInNewWindow") && account.instance.windows.size > 0) {
@@ -400,11 +397,9 @@ export class GoogleApp {
             });
           }
 
-          const googleApp = supportedGoogleAppMatch?.[1];
-
           let powerSaveBlockerId: number | undefined;
 
-          if (googleApp === "meet") {
+          if (matchedSupportedGoogleApp === "meet") {
             powerSaveBlockerId = powerSaveBlocker.start("prevent-display-sleep");
 
             globalShortcut.register("CommandOrControl+Shift+1", () => {
@@ -419,7 +414,7 @@ export class GoogleApp {
           newWindow.once("closed", () => {
             account.instance.windows.delete(newWindow);
 
-            if (googleApp === "meet") {
+            if (matchedSupportedGoogleApp === "meet") {
               globalShortcut.unregister("CommandOrControl+Shift+1");
               globalShortcut.unregister("CommandOrControl+Shift+2");
             }
@@ -478,7 +473,7 @@ export class GoogleApp {
       } else if (WINDOW_OPEN_DOWNLOAD_URL_WHITELIST.some((regex) => regex.test(url))) {
         window.webContents.downloadURL(url);
       } else {
-        openExternalUrl(url, Boolean(supportedGoogleAppMatch));
+        openExternalUrl(url, Boolean(matchedSupportedGoogleApp));
       }
 
       return {

--- a/packages/app/google-app.ts
+++ b/packages/app/google-app.ts
@@ -34,9 +34,7 @@ const WINDOW_OPEN_URL_WHITELIST = [
 ];
 
 const SUPPORTED_GOOGLE_APPS_URL_REGEXP = new RegExp(
-  `(${Object.keys(supportedGoogleApps)
-    .map((app) => (app === "drive" ? "drive(\\.usercontent)?" : app))
-    .join("|")})\\.google\\.com`,
+  `(${Object.keys(supportedGoogleApps).join("|")})(?:\\.usercontent)?\\.google\\.com`,
 );
 
 const WINDOW_OPEN_DOWNLOAD_URL_WHITELIST = [/chat\.google\.com\/u\/\d\/api\/get_attachment_url/];
@@ -271,16 +269,15 @@ export class GoogleApp {
         };
       }
 
-      const matchedSupportedGoogleApp = url.match(SUPPORTED_GOOGLE_APPS_URL_REGEXP)?.[1];
+      const matchedSupportedGoogleApp = url.match(SUPPORTED_GOOGLE_APPS_URL_REGEXP)?.[1] as
+        | SupportedGoogleApp
+        | undefined;
 
       const isGoogleAppEnabledToOpenInApp =
         matchedSupportedGoogleApp &&
         config.get("googleApps.openInApp") &&
         licenseKey.isValid &&
-        (!Object.hasOwn(supportedGoogleApps, matchedSupportedGoogleApp) ||
-          !config
-            .get("googleApps.openInAppExcludedApps")
-            .includes(matchedSupportedGoogleApp as SupportedGoogleApp));
+        !config.get("googleApps.openInAppExcludedApps").includes(matchedSupportedGoogleApp);
 
       if (
         (url.startsWith(GMAIL_URL) ||

--- a/packages/renderer/routes/settings/google-apps.tsx
+++ b/packages/renderer/routes/settings/google-apps.tsx
@@ -7,7 +7,12 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useConfig, useConfigMutation } from "@meru/renderer-lib/react-query";
-import { type GoogleAppsPinnedApp, googleAppsPinnedApps } from "@meru/shared/types";
+import {
+  type GoogleAppsPinnedApp,
+  googleAppsPinnedApps,
+  type SupportedGoogleApp,
+  supportedGoogleApps,
+} from "@meru/shared/types";
 import { Button } from "@meru/ui/components/button";
 import {
   DropdownMenu,
@@ -108,9 +113,9 @@ export function GoogleAppsSettings() {
 
   const excludedApps = config["googleApps.openInAppExcludedApps"];
 
-  const excludedAppLabels = (Object.keys(googleAppsPinnedApps) as GoogleAppsPinnedApp[])
+  const excludedAppLabels = (Object.keys(supportedGoogleApps) as SupportedGoogleApp[])
     .filter((app) => excludedApps.includes(app))
-    .map((app) => googleAppsPinnedApps[app]);
+    .map((app) => supportedGoogleApps[app]);
 
   const visibleExcludedAppLabels = excludedAppLabels.slice(0, 3);
 
@@ -167,7 +172,7 @@ export function GoogleAppsSettings() {
                   />
                   <DropdownMenuContent align="end">
                     {(
-                      Object.entries(googleAppsPinnedApps) as Entries<typeof googleAppsPinnedApps>
+                      Object.entries(supportedGoogleApps) as Entries<typeof supportedGoogleApps>
                     ).map(([app, label]) => (
                       <DropdownMenuCheckboxItem
                         key={app}

--- a/packages/renderer/routes/settings/google-apps.tsx
+++ b/packages/renderer/routes/settings/google-apps.tsx
@@ -10,6 +10,12 @@ import { useConfig, useConfigMutation } from "@meru/renderer-lib/react-query";
 import { type GoogleAppsPinnedApp, googleAppsPinnedApps } from "@meru/shared/types";
 import { Button } from "@meru/ui/components/button";
 import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@meru/ui/components/dropdown-menu";
+import {
   Field,
   FieldContent,
   FieldDescription,
@@ -18,7 +24,8 @@ import {
   FieldSeparator,
 } from "@meru/ui/components/field";
 import { Item, ItemActions, ItemContent, ItemGroup, ItemTitle } from "@meru/ui/components/item";
-import { GripVerticalIcon, PlusIcon, XIcon } from "lucide-react";
+import { ChevronDownIcon, GripVerticalIcon, PlusIcon, XIcon } from "lucide-react";
+import type { Entries } from "type-fest";
 import { ConfigSwitchField } from "@/components/config-switch-field";
 import { GoogleAppIcon } from "@/components/google-app-icon";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
@@ -99,6 +106,23 @@ export function GoogleAppsSettings() {
     (app) => !pinnedApps.includes(app),
   );
 
+  const excludedApps = config["googleApps.openInAppExcludedApps"];
+
+  const excludedAppLabels = (Object.keys(googleAppsPinnedApps) as GoogleAppsPinnedApp[])
+    .filter((app) => excludedApps.includes(app))
+    .map((app) => googleAppsPinnedApps[app]);
+
+  const visibleExcludedAppLabels = excludedAppLabels.slice(0, 3);
+
+  const remainingExcludedAppCount = excludedAppLabels.length - visibleExcludedAppLabels.length;
+
+  const excludedAppsSummary =
+    excludedAppLabels.length === 0
+      ? "None"
+      : remainingExcludedAppCount > 0
+        ? `${visibleExcludedAppLabels.join(", ")} +${remainingExcludedAppCount} excluded`
+        : visibleExcludedAppLabels.join(", ");
+
   return (
     <Settings>
       <SettingsHeader>
@@ -113,12 +137,60 @@ export function GoogleAppsSettings() {
             configKey="googleApps.openInApp"
             licenseKeyRequired
           />
-          <ConfigSwitchField
-            label="Always Open in New Window"
-            description="Always open Google Apps in a new window instead of reusing the same window if it is already open."
-            configKey="googleApps.openAppsInNewWindow"
-            licenseKeyRequired
-          />
+          {config["googleApps.openInApp"] && (
+            <>
+              <ConfigSwitchField
+                label="Always Open in New Window"
+                description="Always open Google Apps in a new window instead of reusing the same window if it is already open."
+                configKey="googleApps.openAppsInNewWindow"
+                licenseKeyRequired
+              />
+              <Field>
+                <FieldContent>
+                  <FieldLabel className="flex items-center gap-2">
+                    Excluded Apps
+                    {!isLicenseKeyValid && <LicenseKeyRequiredFieldBadge />}
+                  </FieldLabel>
+                  <FieldDescription>
+                    Select which Google Apps should open in the external browser instead of the app.
+                  </FieldDescription>
+                </FieldContent>
+                <DropdownMenu>
+                  <DropdownMenuTrigger
+                    disabled={!isLicenseKeyValid}
+                    render={
+                      <Button variant="outline" className="justify-between font-normal">
+                        {isLicenseKeyValid ? excludedAppsSummary : "None"}
+                        <ChevronDownIcon className="opacity-50" />
+                      </Button>
+                    }
+                  />
+                  <DropdownMenuContent align="end">
+                    {(
+                      Object.entries(googleAppsPinnedApps) as Entries<typeof googleAppsPinnedApps>
+                    ).map(([app, label]) => (
+                      <DropdownMenuCheckboxItem
+                        key={app}
+                        checked={config["googleApps.openInAppExcludedApps"].includes(app)}
+                        closeOnClick={false}
+                        onCheckedChange={(checked) => {
+                          configMutation.mutate({
+                            "googleApps.openInAppExcludedApps": checked
+                              ? [...config["googleApps.openInAppExcludedApps"], app]
+                              : config["googleApps.openInAppExcludedApps"].filter(
+                                  (value) => value !== app,
+                                ),
+                          });
+                        }}
+                      >
+                        {label}
+                      </DropdownMenuCheckboxItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </Field>
+            </>
+          )}
           <FieldSeparator />
           <ConfigSwitchField
             label="Show Account Label"

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -41,15 +41,15 @@ export const supportedGoogleApps = {
   drive: "Drive",
   forms: "Forms",
   gemini: "Gemini",
+  groups: "Groups",
   keep: "Keep",
   meet: "Meet",
-  notebooklm: "NotebookLM",
-  tasks: "Tasks",
-  sheets: "Sheets",
-  slides: "Slides",
-  groups: "Groups",
   myaccount: "My Account",
+  notebooklm: "NotebookLM",
+  sheets: "Sheets",
   sites: "Sites",
+  slides: "Slides",
+  tasks: "Tasks",
   voice: "Voice",
 } as const;
 
@@ -67,9 +67,9 @@ const googleAppsPinnedAppKeys = [
   "keep",
   "meet",
   "notebooklm",
-  "tasks",
   "sheets",
   "slides",
+  "tasks",
 ] as const satisfies readonly SupportedGoogleApp[];
 
 export type GoogleAppsPinnedApp = (typeof googleAppsPinnedAppKeys)[number];

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -130,6 +130,7 @@ export type Config = {
   "window.restrictMinimumSize": boolean;
   "trial.expired": boolean;
   "googleApps.openInApp": boolean;
+  "googleApps.openInAppExcludedApps": GoogleAppsPinnedApp[];
   "googleApps.openAppsInNewWindow": boolean;
   "googleApps.pinnedApps": GoogleAppsPinnedApp[];
   "googleApps.showAccountColor": boolean;

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -51,6 +51,16 @@ export const googleAppsPinnedApps = {
 
 export type GoogleAppsPinnedApp = keyof typeof googleAppsPinnedApps;
 
+export const supportedGoogleApps = {
+  ...googleAppsPinnedApps,
+  groups: "Groups",
+  myaccount: "My Account",
+  sites: "Sites",
+  voice: "Voice",
+} as const;
+
+export type SupportedGoogleApp = keyof typeof supportedGoogleApps;
+
 type GmailHashLocation =
   | "inbox"
   | "starred"
@@ -130,7 +140,7 @@ export type Config = {
   "window.restrictMinimumSize": boolean;
   "trial.expired": boolean;
   "googleApps.openInApp": boolean;
-  "googleApps.openInAppExcludedApps": GoogleAppsPinnedApp[];
+  "googleApps.openInAppExcludedApps": SupportedGoogleApp[];
   "googleApps.openAppsInNewWindow": boolean;
   "googleApps.pinnedApps": GoogleAppsPinnedApp[];
   "googleApps.showAccountColor": boolean;

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -55,24 +55,28 @@ export const supportedGoogleApps = {
 
 export type SupportedGoogleApp = keyof typeof supportedGoogleApps;
 
-export const googleAppsPinnedApps = {
-  calendar: supportedGoogleApps.calendar,
-  chat: supportedGoogleApps.chat,
-  classroom: supportedGoogleApps.classroom,
-  contacts: supportedGoogleApps.contacts,
-  docs: supportedGoogleApps.docs,
-  drive: supportedGoogleApps.drive,
-  forms: supportedGoogleApps.forms,
-  gemini: supportedGoogleApps.gemini,
-  keep: supportedGoogleApps.keep,
-  meet: supportedGoogleApps.meet,
-  notebooklm: supportedGoogleApps.notebooklm,
-  tasks: supportedGoogleApps.tasks,
-  sheets: supportedGoogleApps.sheets,
-  slides: supportedGoogleApps.slides,
-} as const;
+const googleAppsPinnedAppKeys = [
+  "calendar",
+  "chat",
+  "classroom",
+  "contacts",
+  "docs",
+  "drive",
+  "forms",
+  "gemini",
+  "keep",
+  "meet",
+  "notebooklm",
+  "tasks",
+  "sheets",
+  "slides",
+] as const satisfies readonly SupportedGoogleApp[];
 
-export type GoogleAppsPinnedApp = keyof typeof googleAppsPinnedApps;
+export type GoogleAppsPinnedApp = (typeof googleAppsPinnedAppKeys)[number];
+
+export const googleAppsPinnedApps = Object.fromEntries(
+  googleAppsPinnedAppKeys.map((key) => [key, supportedGoogleApps[key]]),
+) as Pick<typeof supportedGoogleApps, GoogleAppsPinnedApp>;
 
 type GmailHashLocation =
   | "inbox"

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -32,7 +32,7 @@ export type NotificationTime = {
   days?: number[]; // 0=Sun,1=Mon,...,6=Sat; undefined/empty = all days
 };
 
-export const googleAppsPinnedApps = {
+export const supportedGoogleApps = {
   calendar: "Calendar",
   chat: "Chat",
   classroom: "Classroom",
@@ -47,12 +47,6 @@ export const googleAppsPinnedApps = {
   tasks: "Tasks",
   sheets: "Sheets",
   slides: "Slides",
-} as const;
-
-export type GoogleAppsPinnedApp = keyof typeof googleAppsPinnedApps;
-
-export const supportedGoogleApps = {
-  ...googleAppsPinnedApps,
   groups: "Groups",
   myaccount: "My Account",
   sites: "Sites",
@@ -60,6 +54,25 @@ export const supportedGoogleApps = {
 } as const;
 
 export type SupportedGoogleApp = keyof typeof supportedGoogleApps;
+
+export const googleAppsPinnedApps = {
+  calendar: supportedGoogleApps.calendar,
+  chat: supportedGoogleApps.chat,
+  classroom: supportedGoogleApps.classroom,
+  contacts: supportedGoogleApps.contacts,
+  docs: supportedGoogleApps.docs,
+  drive: supportedGoogleApps.drive,
+  forms: supportedGoogleApps.forms,
+  gemini: supportedGoogleApps.gemini,
+  keep: supportedGoogleApps.keep,
+  meet: supportedGoogleApps.meet,
+  notebooklm: supportedGoogleApps.notebooklm,
+  tasks: supportedGoogleApps.tasks,
+  sheets: supportedGoogleApps.sheets,
+  slides: supportedGoogleApps.slides,
+} as const;
+
+export type GoogleAppsPinnedApp = keyof typeof googleAppsPinnedApps;
 
 type GmailHashLocation =
   | "inbox"


### PR DESCRIPTION
## Summary
This PR adds a new feature that allows users to exclude specific Google Apps from opening within the application, forcing them to open in the external browser instead. This is a refinement of the existing "Open Google Apps in App" feature.

## Key Changes
- **UI Component**: Added a new dropdown menu in the Google Apps settings that displays excluded apps and allows users to select/deselect which apps should open in the browser instead of the app
  - The dropdown is only visible when "Open Google Apps in App" is enabled
  - Shows a count of excluded apps or "None" when no apps are excluded
  - Disabled when license key is not valid
  
- **Configuration**: 
  - Added new config key `googleApps.openInAppExcludedApps` to store an array of excluded Google Apps
  - Initialized with an empty array by default
  
- **Logic**: Updated the Google App window handling to check if a matched Google App is in the excluded list before opening it in the app
  - If an app is excluded, it will open in the external browser instead
  - Respects the existing license key validation requirement

## Implementation Details
- The excluded apps dropdown uses a `DropdownMenuCheckboxItem` component for each available Google App
- The feature properly integrates with the existing config mutation system to persist user selections
- The logic correctly handles the case where a Google App is both enabled to open in-app AND in the excluded list (excluded takes precedence)

https://claude.ai/code/session_01VfCRyVtcHxHPkszuWS74y4