### PR TITLE
Add cascading window positioning for new windows

### DIFF
--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -620,8 +620,8 @@ export class Gmail extends GoogleApp {
 
   createComposeWindow(url: string) {
     const window = new BrowserWindow({
-      autoHideMenuBar: true,
       ...getCascadedWindowBounds({ width: 800, height: 600 }),
+      autoHideMenuBar: true,
       webPreferences: {
         session: this.session,
       },

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -23,6 +23,7 @@ import { main } from "@/main";
 import { appTray } from "@/tray";
 import gmailCSS from "./gmail.css";
 import meruCSS from "./meru.css";
+import { getCascadedWindowBounds } from "@/lib/window";
 import { xmlParser } from "@/lib/xml";
 import z from "zod";
 import { createNotification, isWithinNotificationTimes } from "@/notifications";
@@ -620,6 +621,7 @@ export class Gmail extends GoogleApp {
   createComposeWindow(url: string) {
     const window = new BrowserWindow({
       autoHideMenuBar: true,
+      ...getCascadedWindowBounds({ width: 800, height: 600 }),
       webPreferences: {
         session: this.session,
       },

--- a/packages/app/google-app.ts
+++ b/packages/app/google-app.ts
@@ -21,6 +21,7 @@ import { accounts } from "./accounts";
 import { config } from "./config";
 import { setupWindowContextMenu } from "./context-menu";
 import { ipc } from "./ipc";
+import { getCascadedWindowBounds } from "./lib/window";
 import { licenseKey } from "./license-key";
 import { main } from "./main";
 import { openExternalUrl } from "./url";
@@ -421,14 +422,15 @@ export class GoogleApp {
         };
 
         if (isGmailComposeWindowUrl(url)) {
+          const composeBounds = getCascadedWindowBounds({ width: 800, height: 600 });
+
           return {
             action: "allow",
             createWindow: (inheritedOptions) => {
               const newWindow = new BrowserWindow({
                 ...inheritedOptions,
                 ...newWindowOptions,
-                width: 800,
-                height: 600,
+                ...composeBounds,
                 webPreferences: {
                   ...inheritedOptions.webPreferences,
                   ...newWindowOptions.webPreferences,
@@ -444,8 +446,7 @@ export class GoogleApp {
 
         const newGoogleAppWindow = new BrowserWindow({
           ...newWindowOptions,
-          width: 1280,
-          height: 800,
+          ...getCascadedWindowBounds({ width: 1280, height: 800 }),
         });
 
         setupNewWindow(newGoogleAppWindow);

--- a/packages/app/google-app.ts
+++ b/packages/app/google-app.ts
@@ -422,15 +422,13 @@ export class GoogleApp {
         };
 
         if (isGmailComposeWindowUrl(url)) {
-          const composeBounds = getCascadedWindowBounds({ width: 800, height: 600 });
-
           return {
             action: "allow",
             createWindow: (inheritedOptions) => {
               const newWindow = new BrowserWindow({
                 ...inheritedOptions,
                 ...newWindowOptions,
-                ...composeBounds,
+                ...getCascadedWindowBounds({ width: 800, height: 600 }),
                 webPreferences: {
                   ...inheritedOptions.webPreferences,
                   ...newWindowOptions.webPreferences,

--- a/packages/app/lib/window.ts
+++ b/packages/app/lib/window.ts
@@ -1,0 +1,29 @@
+import { BrowserWindow, screen } from "electron";
+
+const CASCADE_OFFSET = 30;
+
+export function getCascadedWindowBounds({ width, height }: { width: number; height: number }) {
+  const allWindows = BrowserWindow.getAllWindows();
+
+  if (!allWindows.length) {
+    return { width, height };
+  }
+
+  const reference = allWindows.reduce((mostRecent, current) =>
+    current.id > mostRecent.id ? current : mostRecent,
+  );
+
+  const referenceBounds = reference.getBounds();
+  const display = screen.getDisplayMatching(referenceBounds);
+  const workArea = display.workArea;
+
+  let x = referenceBounds.x + CASCADE_OFFSET;
+  let y = referenceBounds.y + CASCADE_OFFSET;
+
+  if (x + width > workArea.x + workArea.width || y + height > workArea.y + workArea.height) {
+    x = workArea.x + CASCADE_OFFSET;
+    y = workArea.y + CASCADE_OFFSET;
+  }
+
+  return { x, y, width, height };
+}


### PR DESCRIPTION
## Summary
Implement cascading window positioning to prevent new windows from opening directly on top of existing windows. When a new window is created, it will be offset from the most recently created window, with automatic repositioning if it would extend beyond the display bounds.

## Changes
- **New utility function**: Added `getCascadedWindowBounds()` in `packages/app/lib/window.ts` that calculates optimal window positions by:
  - Finding the most recently created window
  - Offsetting new windows by 30 pixels in both x and y directions
  - Resetting to the work area origin if the window would exceed display bounds
  
- **Applied cascading positioning** to three window creation points:
  - Generic child windows in `google-app.ts` (800x600)
  - New Google App windows in `google-app.ts` (1280x800)
  - Gmail compose windows in `gmail/index.ts` (800x600)

## Implementation Details
The cascading algorithm uses the display's work area to ensure windows stay within usable screen space. When multiple windows are opened in succession, they will cascade diagonally across the screen, improving visibility and usability.

https://claude.ai/code/session_01RDk9zyjxPR6Ao4ptCbsD9W