### PR TITLE
Add drag-and-drop reordering for pinned Google Apps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,17 +36,30 @@ This installs dependencies and runs postinstall scripts (including the lefthook 
 - Add an empty line before `if` blocks when preceded by other statements.
 - Add an empty line before `return` statements when preceded by other statements.
 
-## Functions Inside Components
+## Functions
 
-- Never use `function` declarations inside a React component or another function. Always use `const` arrow functions:
+- Root-level functions (including React components) use `function` declarations.
+- Nested functions (inside a component or another function) use `const` arrow functions:
 
   ```ts
   // correct
-  const handleClick = () => { ... };
+  function MyComponent() {
+    const handleClick = () => { ... };
+
+    return <button onClick={handleClick} />;
+  }
 
   // wrong
-  function handleClick() { ... }
+  const MyComponent = () => {
+    function handleClick() { ... }
+
+    return <button onClick={handleClick} />;
+  };
   ```
+
+## Dependencies
+
+- Install packages with `bun add <package>` (or `bun add -d <package>` for dev dependencies). Never edit `package.json` or `bun.lock` manually to add or bump dependencies.
 
 ## UI Components
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,13 +111,14 @@ This installs dependencies and runs postinstall scripts (including the lefthook 
 
 - Do not add explicit return types unless necessary — rely on inference.
 
-## Linting
+## Linting and Formatting
 
 - Never use `!` non-null assertions in TypeScript — enforced via `typescript/no-non-null-assertion` in `.oxlintrc.json`. Refactor the code to avoid them instead.
+- Do not run `bun run lint` or `bun run fmt:check` manually. The lefthook pre-commit hook runs `oxfmt` and `oxlint --fix` on staged files on every commit, so formatting and linting are enforced automatically.
 
 ## Type Checking
 
-- Always run `bun types:ci` after making code changes to verify there are no type errors.
+- Always run `bun types:ci` after making code changes to verify there are no type errors. (Type checks are NOT part of the pre-commit hook.)
 
 ## General
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,22 @@ This installs dependencies and runs postinstall scripts (including the lefthook 
 
 - Install packages with `bun add <package>` (or `bun add -d <package>` for dev dependencies). Never edit `package.json` or `bun.lock` manually to add or bump dependencies.
 
+## Inline Single-Use Values
+
+- Don't declare a variable (including a handler function) if it's only used once — inline it at the call site. Prop names like `onClick` or `onDragEnd` already describe what the function does.
+- Only extract a named variable when the logic is complex enough that a name meaningfully improves readability.
+
+  ```ts
+  // correct — inlined
+  <DndContext onDragEnd={(event) => {
+    // ...
+  }} />
+
+  // wrong — named but only used once
+  const handleDragEnd = (event) => { ... };
+  <DndContext onDragEnd={handleDragEnd} />
+  ```
+
 ## UI Components
 
 - Components in `packages/ui` follow shadcn conventions. Many are compound components with named sub-components (e.g. `Item` → `ItemContent`, `ItemActions`, `ItemTitle`, `ItemDescription`). Always read the component file before use to find available sub-components and use them instead of plain `<div>` wrappers.

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,9 @@
       "name": "meru",
       "devDependencies": {
         "@base-ui/react": "^1.4.0",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@electron-toolkit/preload": "^3.0.2",
         "@electron-toolkit/typed-ipc": "^1.0.2",
         "@electron-toolkit/utils": "^4.0.0",
@@ -178,6 +181,14 @@
     "@date-fns/tz": ["@date-fns/tz@1.4.1", "", {}, "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="],
 
     "@develar/schema-utils": ["@develar/schema-utils@2.6.5", "", { "dependencies": { "ajv": "^6.12.0", "ajv-keywords": "^3.4.1" } }, "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig=="],
+
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/sortable": ["@dnd-kit/sortable@10.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.57.1", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.2", "which": "^4.0.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-iKXuo8Nes9Ft4zF3AZOT4FHkl6OV8bHqn61a67qHokkBzSEurnKZAlOkT0FYrRNVGvE6nCfZMtYswyjfXCR1MQ=="],
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   },
   "devDependencies": {
     "@base-ui/react": "^1.4.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/typed-ipc": "^1.0.2",
     "@electron-toolkit/utils": "^4.0.0",

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -302,7 +302,7 @@ function PinnedGoogleApps() {
 
   return (
     <div className="flex gap-2 border-r pr-2 not-first:border-l not-first:pl-2">
-      {config["googleApps.pinnedApps"].sort().map((app) => (
+      {config["googleApps.pinnedApps"].map((app) => (
         <TitlebarIconButton
           key={app}
           onClick={() => {

--- a/packages/renderer/routes/settings/google-apps.tsx
+++ b/packages/renderer/routes/settings/google-apps.tsx
@@ -2,7 +2,6 @@ import {
   closestCenter,
   DndContext,
   type DragEndEvent,
-  KeyboardSensor,
   PointerSensor,
   useSensor,
   useSensors,
@@ -10,7 +9,6 @@ import {
 import {
   arrayMove,
   SortableContext,
-  sortableKeyboardCoordinates,
   useSortable,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
@@ -42,15 +40,15 @@ import { LicenseKeyRequiredFieldBadge } from "@/components/license-key-required-
 import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 
-const SortablePinnedAppItem = ({
+function SortablePinnedAppItem({
   app,
   onUnpin,
   disabled,
 }: {
   app: GoogleAppsPinnedApp;
-  onUnpin: (app: GoogleAppsPinnedApp) => void;
+  onUnpin: () => void;
   disabled: boolean;
-}) => {
+}) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: app,
   });
@@ -63,40 +61,38 @@ const SortablePinnedAppItem = ({
   };
 
   return (
-    <div ref={setNodeRef} style={style}>
-      <Item variant="outline" size="sm">
+    <Item ref={setNodeRef} style={style} variant="outline" size="xs">
+      <Button
+        size="icon-xs"
+        variant="ghost"
+        className="cursor-grab touch-none"
+        disabled={disabled}
+        aria-label={`Drag ${googleAppsPinnedApps[app]} to reorder`}
+        {...attributes}
+        {...listeners}
+      >
+        <GripVerticalIcon />
+      </Button>
+      <ItemMedia variant="icon">
+        <GoogleAppIcon app={app} className="size-3" />
+      </ItemMedia>
+      <ItemContent>
+        <ItemTitle>{googleAppsPinnedApps[app]}</ItemTitle>
+      </ItemContent>
+      <ItemActions>
         <Button
-          size="icon-sm"
+          size="icon-xs"
           variant="ghost"
-          className="cursor-grab touch-none"
+          onClick={onUnpin}
           disabled={disabled}
-          aria-label={`Drag ${googleAppsPinnedApps[app]} to reorder`}
-          {...attributes}
-          {...listeners}
+          aria-label={`Unpin ${googleAppsPinnedApps[app]}`}
         >
-          <GripVerticalIcon />
+          <XIcon />
         </Button>
-        <ItemMedia variant="icon">
-          <GoogleAppIcon app={app} />
-        </ItemMedia>
-        <ItemContent>
-          <ItemTitle>{googleAppsPinnedApps[app]}</ItemTitle>
-        </ItemContent>
-        <ItemActions>
-          <Button
-            size="icon-sm"
-            variant="ghost"
-            onClick={() => onUnpin(app)}
-            disabled={disabled}
-            aria-label={`Unpin ${googleAppsPinnedApps[app]}`}
-          >
-            <XIcon />
-          </Button>
-        </ItemActions>
-      </Item>
-    </div>
+      </ItemActions>
+    </Item>
   );
-};
+}
 
 export function GoogleAppsSettings() {
   const { config } = useConfig();
@@ -105,10 +101,7 @@ export function GoogleAppsSettings() {
 
   const isLicenseKeyValid = useIsLicenseKeyValid();
 
-  const sensors = useSensors(
-    useSensor(PointerSensor),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
-  );
+  const sensors = useSensors(useSensor(PointerSensor));
 
   if (!config) {
     return;
@@ -119,18 +112,6 @@ export function GoogleAppsSettings() {
   const availableApps = (Object.keys(googleAppsPinnedApps) as GoogleAppsPinnedApp[]).filter(
     (app) => !pinnedApps.includes(app),
   );
-
-  const handlePin = (app: GoogleAppsPinnedApp) => {
-    configMutation.mutate({
-      "googleApps.pinnedApps": [...pinnedApps, app],
-    });
-  };
-
-  const handleUnpin = (app: GoogleAppsPinnedApp) => {
-    configMutation.mutate({
-      "googleApps.pinnedApps": pinnedApps.filter((value) => value !== app),
-    });
-  };
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
@@ -210,7 +191,13 @@ export function GoogleAppsSettings() {
                           <SortablePinnedAppItem
                             key={app}
                             app={app}
-                            onUnpin={handleUnpin}
+                            onUnpin={() => {
+                              configMutation.mutate({
+                                "googleApps.pinnedApps": pinnedApps.filter(
+                                  (value) => value !== app,
+                                ),
+                              });
+                            }}
                             disabled={!isLicenseKeyValid}
                           />
                         ))}
@@ -224,18 +211,22 @@ export function GoogleAppsSettings() {
                   <div className="text-xs font-medium text-muted-foreground">Available</div>
                   <ItemGroup>
                     {availableApps.map((app) => (
-                      <Item key={app} variant="outline" size="sm">
+                      <Item key={app} variant="outline" size="xs">
                         <ItemMedia variant="icon">
-                          <GoogleAppIcon app={app} />
+                          <GoogleAppIcon app={app} className="size-3" />
                         </ItemMedia>
                         <ItemContent>
                           <ItemTitle>{googleAppsPinnedApps[app]}</ItemTitle>
                         </ItemContent>
                         <ItemActions>
                           <Button
-                            size="icon-sm"
+                            size="icon-xs"
                             variant="ghost"
-                            onClick={() => handlePin(app)}
+                            onClick={() => {
+                              configMutation.mutate({
+                                "googleApps.pinnedApps": [...pinnedApps, app],
+                              });
+                            }}
                             disabled={!isLicenseKeyValid}
                             aria-label={`Pin ${googleAppsPinnedApps[app]}`}
                           >

--- a/packages/renderer/routes/settings/google-apps.tsx
+++ b/packages/renderer/routes/settings/google-apps.tsx
@@ -1,4 +1,4 @@
-import { closestCenter, DndContext, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
+import { closestCenter, DndContext, PointerSensor, useSensor } from "@dnd-kit/core";
 import {
   arrayMove,
   SortableContext,
@@ -61,7 +61,7 @@ function SortablePinnedAppItem({
       </Button>
       <ItemContent>
         <ItemTitle>
-          <GoogleAppIcon app={app} className="size-3" />
+          <GoogleAppIcon app={app} className="size-4" />
           {googleAppsPinnedApps[app]}
         </ItemTitle>
       </ItemContent>
@@ -87,7 +87,7 @@ export function GoogleAppsSettings() {
 
   const isLicenseKeyValid = useIsLicenseKeyValid();
 
-  const sensors = useSensors(useSensor(PointerSensor));
+  const pointerSensor = useSensor(PointerSensor);
 
   if (!config) {
     return;
@@ -152,7 +152,7 @@ export function GoogleAppsSettings() {
                   </p>
                 ) : (
                   <DndContext
-                    sensors={sensors}
+                    sensors={[pointerSensor]}
                     collisionDetection={closestCenter}
                     onDragEnd={(event) => {
                       const { active, over } = event;
@@ -198,7 +198,7 @@ export function GoogleAppsSettings() {
                       <Item key={app} variant="outline" size="xs">
                         <ItemContent>
                           <ItemTitle>
-                            <GoogleAppIcon app={app} className="size-3" />
+                            <GoogleAppIcon app={app} className="size-4" />
                             {googleAppsPinnedApps[app]}
                           </ItemTitle>
                         </ItemContent>

--- a/packages/renderer/routes/settings/google-apps.tsx
+++ b/packages/renderer/routes/settings/google-apps.tsx
@@ -1,5 +1,23 @@
-import { googleAppsPinnedApps } from "@meru/shared/types";
-import { Checkbox } from "@meru/ui/components/checkbox";
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useConfig, useConfigMutation } from "@meru/renderer-lib/react-query";
+import { type GoogleAppsPinnedApp, googleAppsPinnedApps } from "@meru/shared/types";
+import { Button } from "@meru/ui/components/button";
 import {
   Field,
   FieldContent,
@@ -8,14 +26,77 @@ import {
   FieldLabel,
   FieldSeparator,
 } from "@meru/ui/components/field";
-import { Label } from "@meru/ui/components/label";
-import type { Entries } from "type-fest";
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemGroup,
+  ItemMedia,
+  ItemTitle,
+} from "@meru/ui/components/item";
+import { GripVerticalIcon, PlusIcon, XIcon } from "lucide-react";
 import { ConfigSwitchField } from "@/components/config-switch-field";
+import { GoogleAppIcon } from "@/components/google-app-icon";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
 import { LicenseKeyRequiredFieldBadge } from "@/components/license-key-required-field-badge";
 import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
 import { useIsLicenseKeyValid } from "@/lib/hooks";
-import { useConfig, useConfigMutation } from "@meru/renderer-lib/react-query";
+
+const SortablePinnedAppItem = ({
+  app,
+  onUnpin,
+  disabled,
+}: {
+  app: GoogleAppsPinnedApp;
+  onUnpin: (app: GoogleAppsPinnedApp) => void;
+  disabled: boolean;
+}) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: app,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    zIndex: isDragging ? 1 : undefined,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <Item variant="outline" size="sm">
+        <Button
+          size="icon-sm"
+          variant="ghost"
+          className="cursor-grab touch-none"
+          disabled={disabled}
+          aria-label={`Drag ${googleAppsPinnedApps[app]} to reorder`}
+          {...attributes}
+          {...listeners}
+        >
+          <GripVerticalIcon />
+        </Button>
+        <ItemMedia variant="icon">
+          <GoogleAppIcon app={app} />
+        </ItemMedia>
+        <ItemContent>
+          <ItemTitle>{googleAppsPinnedApps[app]}</ItemTitle>
+        </ItemContent>
+        <ItemActions>
+          <Button
+            size="icon-sm"
+            variant="ghost"
+            onClick={() => onUnpin(app)}
+            disabled={disabled}
+            aria-label={`Unpin ${googleAppsPinnedApps[app]}`}
+          >
+            <XIcon />
+          </Button>
+        </ItemActions>
+      </Item>
+    </div>
+  );
+};
 
 export function GoogleAppsSettings() {
   const { config } = useConfig();
@@ -24,9 +105,47 @@ export function GoogleAppsSettings() {
 
   const isLicenseKeyValid = useIsLicenseKeyValid();
 
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
   if (!config) {
     return;
   }
+
+  const pinnedApps = config["googleApps.pinnedApps"];
+
+  const availableApps = (Object.keys(googleAppsPinnedApps) as GoogleAppsPinnedApp[]).filter(
+    (app) => !pinnedApps.includes(app),
+  );
+
+  const handlePin = (app: GoogleAppsPinnedApp) => {
+    configMutation.mutate({
+      "googleApps.pinnedApps": [...pinnedApps, app],
+    });
+  };
+
+  const handleUnpin = (app: GoogleAppsPinnedApp) => {
+    configMutation.mutate({
+      "googleApps.pinnedApps": pinnedApps.filter((value) => value !== app),
+    });
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (!over || active.id === over.id) {
+      return;
+    }
+
+    const oldIndex = pinnedApps.indexOf(active.id as GoogleAppsPinnedApp);
+    const newIndex = pinnedApps.indexOf(over.id as GoogleAppsPinnedApp);
+
+    configMutation.mutate({
+      "googleApps.pinnedApps": arrayMove(pinnedApps, oldIndex, newIndex),
+    });
+  };
 
   return (
     <Settings>
@@ -69,28 +188,64 @@ export function GoogleAppsSettings() {
                 {!isLicenseKeyValid && <LicenseKeyRequiredFieldBadge />}
               </FieldLabel>
               <FieldDescription>
-                Select which Google Apps are pinned in the titlebar for easy access.
+                Pin Google Apps to the titlebar and drag to reorder.
               </FieldDescription>
             </FieldContent>
-            <div className="grid grid-cols-2 gap-3">
-              {(Object.entries(googleAppsPinnedApps) as Entries<typeof googleAppsPinnedApps>).map(
-                ([app, label]) => (
-                  <div className="flex items-center gap-2" key={app}>
-                    <Checkbox
-                      id={app}
-                      checked={isLicenseKeyValid && config["googleApps.pinnedApps"].includes(app)}
-                      onCheckedChange={(checked) => {
-                        configMutation.mutate({
-                          "googleApps.pinnedApps": checked
-                            ? [...config["googleApps.pinnedApps"], app]
-                            : config["googleApps.pinnedApps"].filter((value) => value !== app),
-                        });
-                      }}
-                      disabled={!isLicenseKeyValid}
-                    />
-                    <Label htmlFor={app}>{label}</Label>
-                  </div>
-                ),
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-col gap-2">
+                <div className="text-xs font-medium text-muted-foreground">Pinned</div>
+                {pinnedApps.length === 0 ? (
+                  <p className="rounded-lg border border-dashed px-3 py-4 text-center text-sm text-muted-foreground">
+                    No pinned apps. Add apps from Available below.
+                  </p>
+                ) : (
+                  <DndContext
+                    sensors={sensors}
+                    collisionDetection={closestCenter}
+                    onDragEnd={handleDragEnd}
+                  >
+                    <SortableContext items={pinnedApps} strategy={verticalListSortingStrategy}>
+                      <ItemGroup>
+                        {pinnedApps.map((app) => (
+                          <SortablePinnedAppItem
+                            key={app}
+                            app={app}
+                            onUnpin={handleUnpin}
+                            disabled={!isLicenseKeyValid}
+                          />
+                        ))}
+                      </ItemGroup>
+                    </SortableContext>
+                  </DndContext>
+                )}
+              </div>
+              {availableApps.length > 0 && (
+                <div className="flex flex-col gap-2">
+                  <div className="text-xs font-medium text-muted-foreground">Available</div>
+                  <ItemGroup>
+                    {availableApps.map((app) => (
+                      <Item key={app} variant="outline" size="sm">
+                        <ItemMedia variant="icon">
+                          <GoogleAppIcon app={app} />
+                        </ItemMedia>
+                        <ItemContent>
+                          <ItemTitle>{googleAppsPinnedApps[app]}</ItemTitle>
+                        </ItemContent>
+                        <ItemActions>
+                          <Button
+                            size="icon-sm"
+                            variant="ghost"
+                            onClick={() => handlePin(app)}
+                            disabled={!isLicenseKeyValid}
+                            aria-label={`Pin ${googleAppsPinnedApps[app]}`}
+                          >
+                            <PlusIcon />
+                          </Button>
+                        </ItemActions>
+                      </Item>
+                    ))}
+                  </ItemGroup>
+                </div>
               )}
             </div>
           </Field>

--- a/packages/renderer/routes/settings/google-apps.tsx
+++ b/packages/renderer/routes/settings/google-apps.tsx
@@ -61,7 +61,7 @@ function SortablePinnedAppItem({
       </Button>
       <ItemContent>
         <ItemTitle>
-          <GoogleAppIcon app={app} className="size-4" />
+          <GoogleAppIcon app={app} className="size-3.5" />
           {googleAppsPinnedApps[app]}
         </ItemTitle>
       </ItemContent>
@@ -198,7 +198,7 @@ export function GoogleAppsSettings() {
                       <Item key={app} variant="outline" size="xs">
                         <ItemContent>
                           <ItemTitle>
-                            <GoogleAppIcon app={app} className="size-4" />
+                            <GoogleAppIcon app={app} className="size-3.5" />
                             {googleAppsPinnedApps[app]}
                           </ItemTitle>
                         </ItemContent>

--- a/packages/renderer/routes/settings/google-apps.tsx
+++ b/packages/renderer/routes/settings/google-apps.tsx
@@ -1,11 +1,4 @@
-import {
-  closestCenter,
-  DndContext,
-  type DragEndEvent,
-  PointerSensor,
-  useSensor,
-  useSensors,
-} from "@dnd-kit/core";
+import { closestCenter, DndContext, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
 import {
   arrayMove,
   SortableContext,
@@ -113,21 +106,6 @@ export function GoogleAppsSettings() {
     (app) => !pinnedApps.includes(app),
   );
 
-  const handleDragEnd = (event: DragEndEvent) => {
-    const { active, over } = event;
-
-    if (!over || active.id === over.id) {
-      return;
-    }
-
-    const oldIndex = pinnedApps.indexOf(active.id as GoogleAppsPinnedApp);
-    const newIndex = pinnedApps.indexOf(over.id as GoogleAppsPinnedApp);
-
-    configMutation.mutate({
-      "googleApps.pinnedApps": arrayMove(pinnedApps, oldIndex, newIndex),
-    });
-  };
-
   return (
     <Settings>
       <SettingsHeader>
@@ -183,7 +161,20 @@ export function GoogleAppsSettings() {
                   <DndContext
                     sensors={sensors}
                     collisionDetection={closestCenter}
-                    onDragEnd={handleDragEnd}
+                    onDragEnd={(event) => {
+                      const { active, over } = event;
+
+                      if (!over || active.id === over.id) {
+                        return;
+                      }
+
+                      const oldIndex = pinnedApps.indexOf(active.id as GoogleAppsPinnedApp);
+                      const newIndex = pinnedApps.indexOf(over.id as GoogleAppsPinnedApp);
+
+                      configMutation.mutate({
+                        "googleApps.pinnedApps": arrayMove(pinnedApps, oldIndex, newIndex),
+                      });
+                    }}
                   >
                     <SortableContext items={pinnedApps} strategy={verticalListSortingStrategy}>
                       <ItemGroup>

--- a/packages/renderer/routes/settings/google-apps.tsx
+++ b/packages/renderer/routes/settings/google-apps.tsx
@@ -17,14 +17,7 @@ import {
   FieldLabel,
   FieldSeparator,
 } from "@meru/ui/components/field";
-import {
-  Item,
-  ItemActions,
-  ItemContent,
-  ItemGroup,
-  ItemMedia,
-  ItemTitle,
-} from "@meru/ui/components/item";
+import { Item, ItemActions, ItemContent, ItemGroup, ItemTitle } from "@meru/ui/components/item";
 import { GripVerticalIcon, PlusIcon, XIcon } from "lucide-react";
 import { ConfigSwitchField } from "@/components/config-switch-field";
 import { GoogleAppIcon } from "@/components/google-app-icon";
@@ -66,11 +59,11 @@ function SortablePinnedAppItem({
       >
         <GripVerticalIcon />
       </Button>
-      <ItemMedia variant="icon">
-        <GoogleAppIcon app={app} className="size-3" />
-      </ItemMedia>
       <ItemContent>
-        <ItemTitle>{googleAppsPinnedApps[app]}</ItemTitle>
+        <ItemTitle>
+          <GoogleAppIcon app={app} className="size-3" />
+          {googleAppsPinnedApps[app]}
+        </ItemTitle>
       </ItemContent>
       <ItemActions>
         <Button
@@ -200,14 +193,14 @@ export function GoogleAppsSettings() {
               {availableApps.length > 0 && (
                 <div className="flex flex-col gap-2">
                   <div className="text-xs font-medium text-muted-foreground">Available</div>
-                  <ItemGroup>
+                  <ItemGroup className="grid grid-cols-2">
                     {availableApps.map((app) => (
                       <Item key={app} variant="outline" size="xs">
-                        <ItemMedia variant="icon">
-                          <GoogleAppIcon app={app} className="size-3" />
-                        </ItemMedia>
                         <ItemContent>
-                          <ItemTitle>{googleAppsPinnedApps[app]}</ItemTitle>
+                          <ItemTitle>
+                            <GoogleAppIcon app={app} className="size-3" />
+                            {googleAppsPinnedApps[app]}
+                          </ItemTitle>
                         </ItemContent>
                         <ItemActions>
                           <Button


### PR DESCRIPTION
## Summary
Refactored the Google Apps settings UI to support drag-and-drop reordering of pinned apps, replacing the previous checkbox-based selection interface with a more intuitive two-section layout (Pinned and Available).

## Key Changes
- **Drag-and-drop reordering**: Integrated `@dnd-kit` library to enable users to reorder pinned apps by dragging
- **New UI layout**: Split the interface into "Pinned" and "Available" sections
  - Pinned apps display with drag handles and unpin buttons
  - Available apps show in a grid with pin buttons
  - Empty state message when no apps are pinned
- **New component**: Created `SortablePinnedAppItem` to handle individual pinned app rendering with drag functionality
- **Removed sorting**: Removed automatic `.sort()` from titlebar display to preserve user-defined order
- **Updated documentation**: Clarified code style guidelines in CLAUDE.md regarding function declarations and inline single-use values

## Implementation Details
- Used `@dnd-kit/core` with `PointerSensor` for drag detection and `closestCenter` collision detection
- Leveraged `@dnd-kit/sortable` for list reordering with `verticalListSortingStrategy`
- Integrated `GoogleAppIcon` component for visual consistency
- Maintained license key validation for all interactive elements
- Updated field description to reflect new drag-and-drop capability

https://claude.ai/code/session_011ZpkLjnhVAzfSBroAuw8Ls