### PR TITLE
Document naming conventions in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ This installs dependencies and runs postinstall scripts (including the lefthook 
   - `startMinutes`/`endMinutes` not `s`/`e`
   - `aStart`/`aEnd`/`bStart`/`bEnd` not `aS`/`aE`/`bS`/`bE`
   - `event` not `e`, `error` not `err`, `index` not `i` (unless in a for loop counter)
+- Avoid generic/contextless names even when they're full words — pick a name that carries the domain. `raw`, `data`, `parsed`, `record`, `result`, `value`, `item`, `obj`, `tmp` are all red flags on their own. Prefer `gtkDecorationLayout` over `layout`, `savedLanguages` over `languages`, `accountConfigs` over `configs`. This lets a reader understand a line without tracing back to where the value came from.
 
 ## Code Formatting
 
@@ -56,6 +57,14 @@ This installs dependencies and runs postinstall scripts (including the lefthook 
     return <button onClick={handleClick} />;
   };
   ```
+
+- Name boolean-returning functions with the bare predicate prefix — `is`, `has`, `can`, `should`, `did`, `will` — matching Node.js, Lodash, React, and typescript-eslint's `naming-convention` rule (e.g. `isWithinNotificationTimes`, `isMailtoUrl`, `hasOverlap`). Don't prefix with `get` to dodge a variable-name collision. Avoid the collision one of these ways instead:
+  - Inline single-use calls — `if (!isWithinNotificationTimes()) { ... }` needs no local.
+  - If a local is needed, name it for its purpose rather than mirroring the function — e.g. `const shouldSuppressNotification = !isWithinNotificationTimes();`.
+
+## File Naming
+
+- Name files by the domain/topic they cover, not by the single function they currently contain. Prefer generic, higher-level names (`lib/linux.ts`, `lib/fs.ts`) over function-specific ones (`lib/linux-window-controls.ts`, `lib/file-exists.ts`) so related helpers can accrete into the same file over time instead of each living in its own tiny file. Only split when a file grows large enough that the current topic is clearly two topics.
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

Adds three naming-convention rules to `CLAUDE.md`, all anchored in identifiers that exist in the codebase today:

- **Variable naming** — flag generic/contextless locals (`raw`, `data`, `parsed`, `record`, `result`, `value`, `item`, `obj`, `tmp`). Cites real examples: `gtkDecorationLayout` (`packages/app/lib/linux.ts:58`), `savedLanguages` (`packages/app/spellchecker.ts:12`), `accountConfigs` (`packages/app/accounts.ts:90`).
- **Function naming** — boolean-returning functions use the bare predicate prefix (`is`/`has`/`can`/`should`/`did`/`will`), matching Node.js/Lodash/React/typescript-eslint convention. Cites real predicates: `isWithinNotificationTimes` (`packages/app/notifications.ts:10`, called inline at `packages/app/gmail/index.ts:462`), `isMailtoUrl` (`packages/app/protocol.ts:19`), `hasOverlap` (`packages/renderer/routes/settings/notifications.tsx:41`). Discourages `getIs*` workarounds; resolves collisions by inlining or purpose-based local names.
- **File naming** — prefer domain/topic file names (`lib/linux.ts`, `lib/fs.ts`) over single-function names (`lib/linux-window-controls.ts`, `lib/file-exists.ts`) so related helpers can accrete without renames.

Docs-only — no code touched.

## Test plan

- [ ] Read the three new bullets and confirm every cited identifier exists on `main`.