### PR TITLE
Centralize electron-log imports through lib/log wrapper

### DIFF
--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -23,12 +23,12 @@ import { main } from "@/main";
 import { appTray } from "@/tray";
 import gmailCSS from "./gmail.css";
 import meruCSS from "./meru.css";
+import { log } from "@/lib/log";
 import { getCascadedWindowBounds } from "@/lib/window";
 import { xmlParser } from "@/lib/xml";
 import z from "zod";
 import { createNotification, isWithinNotificationTimes } from "@/notifications";
 import { ms } from "@meru/shared/ms";
-import log from "electron-log";
 import { wait } from "@meru/shared/utils";
 
 export const GMAIL_USER_STYLES_PATH = path.join(app.getPath("userData"), "gmail-user-styles.css");

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -28,7 +28,7 @@ import { appUpdater } from "./updater";
 import { downloads } from "./downloads";
 import { MAX_RECENT_DOWNLOAD_HISTORY_ITEMS } from "@meru/shared/constants";
 import { fileExists } from "./lib/fs";
-import log from "electron-log";
+import { log } from "./lib/log";
 
 class Ipc {
   main = new IpcListener<IpcMainEvents>();

--- a/packages/app/lib/log.ts
+++ b/packages/app/lib/log.ts
@@ -1,0 +1,3 @@
+import logPrimitive from "electron-log/main";
+
+export const log = logPrimitive;

--- a/packages/app/license-key.ts
+++ b/packages/app/license-key.ts
@@ -2,9 +2,9 @@ import { app, dialog, type MessageBoxOptions } from "electron";
 import { machineId } from "node-machine-id";
 import { config } from "@/config";
 import { apiClient, apiFallbackClient } from "./api-client";
+import { log } from "./lib/log";
 import { openExternalUrl } from "./url";
 import isOnline from "is-online";
-import log from "electron-log";
 import { serializeError } from "serialize-error";
 
 class LicenseKey {

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -11,11 +11,11 @@ import {
   nativeImage,
   shell,
 } from "electron";
-import log from "electron-log";
 import { accounts } from "@/accounts";
 import { config } from "@/config";
 import { showRestartDialog } from "@/dialogs";
 import { ipc } from "@/ipc";
+import { log } from "@/lib/log";
 import { main } from "@/main";
 import { appUpdater } from "@/updater";
 import { openExternalUrl } from "@/url";

--- a/packages/app/trial.ts
+++ b/packages/app/trial.ts
@@ -3,11 +3,11 @@ import { machineId } from "node-machine-id";
 import { apiClient, apiFallbackClient } from "./api-client";
 import { config } from "./config";
 import { ipc } from "./ipc";
+import { log } from "./lib/log";
 import { licenseKey } from "./license-key";
 import { main } from "./main";
 import { openExternalUrl } from "./url";
 import isOnline from "is-online";
-import log from "electron-log";
 import { serializeError } from "serialize-error";
 
 class Trial {

--- a/packages/app/updater.ts
+++ b/packages/app/updater.ts
@@ -1,10 +1,10 @@
 import { is } from "@electron-toolkit/utils";
 import { ms } from "@meru/shared/ms";
 import type { UpdateDownloadedEvent } from "electron-updater";
-import log from "electron-log";
 import { autoUpdater } from "electron-updater";
 import { config } from "@/config";
 import { ipc } from "./ipc";
+import { log } from "./lib/log";
 import { main } from "./main";
 import { appState } from "./state";
 


### PR DESCRIPTION
## Summary

Adds `packages/app/lib/log.ts` wrapping `electron-log/main` and re-exporting it as a named `log` export. Migrates the six existing direct consumers to the wrapper so future log-config changes (formatting, transports, levels, etc.) only need to touch one file.

## Changes

- **New file**: `packages/app/lib/log.ts` — one-line wrapper around `electron-log/main`.
- **Updated imports** in 6 files, replacing `import log from "electron-log"` with `import { log } from "./lib/log"` (or `@/lib/log` to match the file's existing import style):
  - `packages/app/gmail/index.ts`
  - `packages/app/ipc.ts`
  - `packages/app/license-key.ts`
  - `packages/app/menu.ts`
  - `packages/app/trial.ts`
  - `packages/app/updater.ts`

Switching to the `electron-log/main` subpath explicitly (rather than the default export) is the main-process-recommended entry in electron-log v5.

Call sites are untouched — `log.info`, `log.warn`, `log.error`, etc. behave identically.

## Test plan

- [ ] `bun types:ci` passes.
- [ ] `grep -r 'from "electron-log"' packages/` returns no matches in app code (only `bun.lock` / `package.json`).
- [ ] Trigger a logged error path (e.g. activate an invalid license key) and confirm the log line still appears in the usual location.