### PR TITLE
Rename `getIsLinuxWindowControlsEnabled` to `isLinuxWindowControlsEnabled`

### DIFF
--- a/packages/app/lib/linux.ts
+++ b/packages/app/lib/linux.ts
@@ -7,7 +7,7 @@ import { promisify } from "node:util";
 
 const execFile = promisify(childProcess.execFile);
 
-let isLinuxWindowControlsEnabled: boolean | null = null;
+let cachedIsLinuxWindowControlsEnabled: boolean | null = null;
 
 async function getGtkDecorationLayout() {
   try {
@@ -46,19 +46,19 @@ async function getGtkDecorationLayout() {
   return null;
 }
 
-export async function getIsLinuxWindowControlsEnabled() {
+export async function isLinuxWindowControlsEnabled() {
   if (!platform.isLinux) {
-    throw new Error("getIsLinuxWindowControlsEnabled is only supported on Linux");
+    throw new Error("isLinuxWindowControlsEnabled is only supported on Linux");
   }
 
-  if (typeof isLinuxWindowControlsEnabled === "boolean") {
-    return isLinuxWindowControlsEnabled;
+  if (typeof cachedIsLinuxWindowControlsEnabled === "boolean") {
+    return cachedIsLinuxWindowControlsEnabled;
   }
 
   const gtkDecorationLayout = await getGtkDecorationLayout();
 
-  isLinuxWindowControlsEnabled =
+  cachedIsLinuxWindowControlsEnabled =
     gtkDecorationLayout === null ? true : /close|minimize|maximize/.test(gtkDecorationLayout);
 
-  return isLinuxWindowControlsEnabled;
+  return cachedIsLinuxWindowControlsEnabled;
 }

--- a/packages/app/main.ts
+++ b/packages/app/main.ts
@@ -4,7 +4,7 @@ import { APP_TITLEBAR_HEIGHT } from "@meru/shared/constants";
 import { app, BrowserWindow, nativeTheme, screen } from "electron";
 import { accounts } from "@/accounts";
 import { config, DEFAULT_WINDOW_STATE_BOUNDS } from "@/config";
-import { getIsLinuxWindowControlsEnabled } from "@/lib/linux";
+import { isLinuxWindowControlsEnabled } from "@/lib/linux";
 import { appState } from "@/state";
 import { openExternalUrl } from "@/url";
 import { ipc } from "./ipc";
@@ -74,7 +74,7 @@ class Main {
   }
 
   async updateTitlebarOverlay() {
-    if (!platform.isLinux || (await getIsLinuxWindowControlsEnabled())) {
+    if (!platform.isLinux || (await isLinuxWindowControlsEnabled())) {
       this.window.setTitleBarOverlay(this.getTitlebarOverlayOptions());
     }
   }
@@ -101,7 +101,7 @@ class Main {
       show: false,
       titleBarStyle: platform.isMacOS ? "hiddenInset" : "hidden",
       titleBarOverlay:
-        !platform.isLinux || (await getIsLinuxWindowControlsEnabled())
+        !platform.isLinux || (await isLinuxWindowControlsEnabled())
           ? this.getTitlebarOverlayOptions()
           : false,
       darkTheme: nativeTheme.shouldUseDarkColors,


### PR DESCRIPTION
## Summary

Conforms `packages/app/lib/linux.ts` to the naming conventions documented in CLAUDE.md (PR #523):

- **Function**: `getIsLinuxWindowControlsEnabled` → `isLinuxWindowControlsEnabled`. Boolean-returning functions use the bare predicate prefix (`is`/`has`/`can`/`should`), not a `getIs` workaround.
- **Cache variable**: `isLinuxWindowControlsEnabled` (at module scope, the predicate form) → `cachedIsLinuxWindowControlsEnabled`. Mirrors the full exported function name with a `cached` prefix so the cache stays obviously tied to its producer and no longer collides with the function name.
- **Error message**: updated to reference the new function name.
- **Call sites**: `packages/app/main.ts` updated (two spots).

## Test plan

- [x] `bun types:ci` passes.
- [ ] On Linux, launch the app and confirm the title-bar overlay renders correctly (unchanged behavior — pure rename).