### PR TITLE
add TODO.md and scope/review guidance in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,13 @@ This installs dependencies and runs postinstall scripts (including the lefthook 
 
 - Follow the patterns and naming of the existing codebase. When in doubt, find a similar example in the codebase and match it exactly.
 
+## Scope and Review Bandwidth
+
+- Keep the initial slice of a feature small and self-contained. Split larger work into incremental changes the user can read one at a time — mental bandwidth to review is a real constraint, and a sprawling change across many files is harder to absorb than three smaller ones.
+- When the full feature spans several concerns (e.g. IPC wiring, UI, state broadcasting), land the plumbing first, then each consumer in its own turn. Track the follow-ups inline in the conversation and/or in the PR description so they aren't lost.
+- `TODO.md` (at the repo root) is reserved for work that should be picked up in a **new session** — items unrelated enough to the current feature's goal that they shouldn't ride along with it. Do not use `TODO.md` as a backlog for the in-progress feature itself.
+- This is not about doing less work overall — it's about staging it so each step is easy to read, question, and approve.
+
 ## Release Notes
 
 - Release notes live only on GitHub Releases — do not commit a `RELEASE_NOTES.md` or `CHANGELOG.md` file. Match the style of recent published releases at https://github.com/zoidsh/meru/releases.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,7 @@
+# TODO
+
+Follow-up work that should be picked up in a **new session** — items unrelated enough to their originating feature that they shouldn't ride along with it.
+
+## Google App context-menu entries
+
+Add "Copy Link" and "Open in Default Browser" entries to the right-click context menu for non-Gmail-view windows — extend `setupWindowContextMenu` in `packages/app/context-menu.ts`, guarded with `window !== accounts.getSelectedAccount().instance.gmail.view`. Gives immediate discoverability even for users who don't end up using the toolbar UI.


### PR DESCRIPTION
## Summary

- Introduce `TODO.md` at the repo root as a holding place for follow-up work that belongs in a **new session** — items unrelated enough to the in-progress feature that they shouldn't ride along with it. Seeds it with the "Google App context-menu entries" task.
- Add a `## Scope and Review Bandwidth` section to `CLAUDE.md` that codifies the small-scope convention: keep the initial slice of a feature small, split larger work into incremental changes, and distinguish in-session follow-ups (tracked in the conversation / PR description) from `TODO.md`-worthy items (new session).

No runtime changes.

## Test plan

- [ ] Skim `CLAUDE.md` — the new section reads cleanly alongside the existing conventions.
- [ ] `TODO.md` renders correctly on GitHub.
