### PR TITLE
move time conversion helpers to @meru/shared/time

### DIFF
--- a/packages/app/lib/notifications.ts
+++ b/packages/app/lib/notifications.ts
@@ -1,9 +1,5 @@
+import { timeToMinutes } from "@meru/shared/time";
 import type { NotificationTime } from "@meru/shared/types";
-
-function timeToMinutes(time: string) {
-  const colonIndex = time.indexOf(":");
-  return Number(time.slice(0, colonIndex)) * 60 + Number(time.slice(colonIndex + 1));
-}
 
 export function checkWithinNotificationTimes(times: NotificationTime[], now: Date) {
   if (!times.length) {

--- a/packages/renderer/routes/settings/notifications.tsx
+++ b/packages/renderer/routes/settings/notifications.tsx
@@ -29,14 +29,10 @@ import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/comp
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { NOTIFICATION_SOUNDS, playNotificationSound } from "@/lib/notifications";
 import { useConfig, useConfigMutation } from "@meru/renderer-lib/react-query";
+import { minutesToTime, timeToMinutes } from "@meru/shared/time";
 import type { NotificationTime } from "@meru/shared/types";
 import { Plus, X } from "lucide-react";
 import { toast } from "sonner";
-
-function timeToMinutes(time: string) {
-  const colonIndex = time.indexOf(":");
-  return Number(time.slice(0, colonIndex)) * 60 + Number(time.slice(colonIndex + 1));
-}
 
 function hasOverlap(times: NotificationTime[]) {
   return times.some((timeA, index) =>
@@ -49,12 +45,6 @@ function hasOverlap(times: NotificationTime[]) {
       return aStart < bEnd && bStart < aEnd;
     }),
   );
-}
-
-function minutesToTime(totalMinutes: number) {
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
-  return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
 }
 
 function findFreeSlot(existingTimes: NotificationTime[]) {

--- a/packages/shared/time.ts
+++ b/packages/shared/time.ts
@@ -1,0 +1,10 @@
+export function timeToMinutes(time: string) {
+  const colonIndex = time.indexOf(":");
+  return Number(time.slice(0, colonIndex)) * 60 + Number(time.slice(colonIndex + 1));
+}
+
+export function minutesToTime(totalMinutes: number) {
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
+}


### PR DESCRIPTION
`timeToMinutes` was duplicated byte-for-byte between `packages/app/lib/notifications.ts` and `packages/renderer/routes/settings/notifications.tsx`, and `minutesToTime` was only defined in the renderer copy even though it's a generic helper. Consolidating both into `@meru/shared/time` (following the `@meru/shared/ms` pattern) removes the duplication and makes them reachable from any process.

## Test plan
- [ ] `bun types:ci` passes
- [ ] Settings → Notifications: add/edit notification time windows; the UI still formats times correctly
- [ ] Notifications main-process flow: verify `checkWithinNotificationTimes` still gates notifications to the configured windows