### PR TITLE
dedupe electron-api preload bootstrap into @meru/shared

### DIFF
--- a/packages/gmail-preload/index.ts
+++ b/packages/gmail-preload/index.ts
@@ -1,4 +1,4 @@
-import "./electron-api";
+import "@meru/shared/electron-api";
 import "./ipc";
 import { moveAttachmentsToTop } from "./attachments";
 import { openComposeInNewWindow } from "./compose";

--- a/packages/google-app-preload/electron-api.ts
+++ b/packages/google-app-preload/electron-api.ts
@@ -1,9 +1,0 @@
-import { type ElectronAPI, electronAPI } from "@electron-toolkit/preload";
-
-declare global {
-  interface Window {
-    electron: ElectronAPI;
-  }
-}
-
-window.electron = electronAPI;

--- a/packages/google-app-preload/index.ts
+++ b/packages/google-app-preload/index.ts
@@ -1,4 +1,4 @@
-import "./electron-api";
+import "@meru/shared/electron-api";
 import { initMailPreload } from "./apps/mail";
 import { initMeetPreload } from "./apps/meet";
 

--- a/packages/shared/electron-api.ts
+++ b/packages/shared/electron-api.ts
@@ -1,3 +1,4 @@
+/// <reference lib="dom" />
 import { type ElectronAPI, electronAPI } from "@electron-toolkit/preload";
 
 declare global {


### PR DESCRIPTION
`packages/gmail-preload/electron-api.ts` and `packages/google-app-preload/electron-api.ts` were byte-identical — both declared the `window.electron` global and assigned `electronAPI` to it. Moved the file to `@meru/shared/electron-api` so both preloads import the same module. A `/// <reference lib="dom" />` is needed because `packages/shared` uses the `no-dom` tsconfig.

## Test plan
- [ ] `bun types:ci` passes
- [ ] Gmail preload: Gmail loads, `window.electron` is exposed in the renderer (check with devtools `window.electron`)
- [ ] Google Apps preload: open a supported Google app (Mail/Meet) and confirm the preload initialises without console errors