### PR TITLE
extract observeBodyMutations helper into @meru/shared/dom

### DIFF
--- a/packages/gmail-preload/index.ts
+++ b/packages/gmail-preload/index.ts
@@ -1,5 +1,6 @@
 import "./electron-api";
 import "./ipc";
+import { observeBodyMutations } from "@meru/shared/dom";
 import { moveAttachmentsToTop } from "./attachments";
 import { openComposeInNewWindow } from "./compose";
 import { initCss } from "./css";
@@ -40,12 +41,5 @@ document.addEventListener("DOMContentLoaded", () => {
   initUrlPreview();
   initToaster();
 
-  const observer = new MutationObserver(() => {
-    runFeatures();
-  });
-
-  observer.observe(document.body, {
-    childList: true,
-    subtree: true,
-  });
+  observeBodyMutations(runFeatures);
 });

--- a/packages/google-app-preload/apps/mail.ts
+++ b/packages/google-app-preload/apps/mail.ts
@@ -1,3 +1,4 @@
+import { observeBodyMutations } from "@meru/shared/dom";
 import { GMAIL_PRELOAD_ARGUMENTS, isGmailComposeWindowUrl } from "@meru/shared/gmail";
 import { $ } from "select-dom";
 import { ipcMain, ipcRenderer } from "@/ipc";
@@ -39,11 +40,7 @@ function closeComposeWindowAfterSend() {
 export function initMailPreload() {
   if (isGmailComposeWindowUrl(window.location.href)) {
     document.addEventListener("DOMContentLoaded", () => {
-      const observer = new MutationObserver(() => {
-        closeComposeWindowAfterSend();
-      });
-
-      observer.observe(document.body, { childList: true, subtree: true });
+      observeBodyMutations(closeComposeWindowAfterSend);
     });
 
     return;

--- a/packages/shared/dom.ts
+++ b/packages/shared/dom.ts
@@ -1,0 +1,14 @@
+/// <reference lib="dom" />
+
+export function observeBodyMutations(callback: () => void) {
+  const observer = new MutationObserver(() => {
+    callback();
+  });
+
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+  });
+
+  return observer;
+}


### PR DESCRIPTION
`packages/gmail-preload/index.ts` and `packages/google-app-preload/apps/mail.ts` both set up a `MutationObserver` watching `document.body` with `{ childList: true, subtree: true }`. Extracted the pattern to `observeBodyMutations` in a new `@meru/shared/dom` module so future preload work can reuse it.

## Test plan
- [ ] `bun types:ci` passes
- [ ] Gmail preload: unread count, sender icons, attachments-to-top, and other DOM-observed features still fire as Gmail updates the DOM
- [ ] Google Apps Mail preload: compose-window "close after send" behavior still fires