### PR TITLE
extract downloads.markDownloadMissingIfGone helper

### DIFF
--- a/packages/app/downloads.ts
+++ b/packages/app/downloads.ts
@@ -31,6 +31,26 @@ class Downloads {
     return item;
   }
 
+  async markDownloadMissingIfGone(id: string, filePath: string) {
+    if (await fileExists(filePath)) {
+      return false;
+    }
+
+    const downloadHistory = config.get("downloads.history");
+
+    for (const item of downloadHistory) {
+      if (item.id === id) {
+        item.exists = false;
+
+        break;
+      }
+    }
+
+    config.set("downloads.history", downloadHistory);
+
+    return true;
+  }
+
   init() {
     const openFolderWhenDone = config.get("downloads.openFolderWhenDone");
 

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -27,7 +27,6 @@ import { MAILTO_PROTOCOL } from "./protocol";
 import { appUpdater } from "./updater";
 import { downloads } from "./downloads";
 import { MAX_RECENT_DOWNLOAD_HISTORY_ITEMS } from "@meru/shared/constants";
-import { fileExists } from "./lib/fs";
 import { log } from "./lib/log";
 
 class Ipc {
@@ -144,19 +143,7 @@ class Ipc {
     });
 
     ipc.main.on("downloads.openFile", async (_event, { id, filePath }) => {
-      if (!(await fileExists(filePath))) {
-        const downloadHistory = config.get("downloads.history");
-
-        for (const item of downloadHistory) {
-          if (item.id === id) {
-            item.exists = false;
-
-            break;
-          }
-        }
-
-        config.set("downloads.history", downloadHistory);
-
+      if (await downloads.markDownloadMissingIfGone(id, filePath)) {
         return;
       }
 
@@ -164,19 +151,7 @@ class Ipc {
     });
 
     ipc.main.on("downloads.showFileInFolder", async (_event, { id, filePath }) => {
-      if (!(await fileExists(filePath))) {
-        const downloadHistory = config.get("downloads.history");
-
-        for (const item of downloadHistory) {
-          if (item.id === id) {
-            item.exists = false;
-
-            break;
-          }
-        }
-
-        config.set("downloads.history", downloadHistory);
-
+      if (await downloads.markDownloadMissingIfGone(id, filePath)) {
         return;
       }
 
@@ -395,19 +370,7 @@ class Ipc {
     });
 
     ipc.main.on("downloads.dragFile", async (event, { id, filePath }) => {
-      if (!(await fileExists(filePath))) {
-        const downloadHistory = config.get("downloads.history");
-
-        for (const item of downloadHistory) {
-          if (item.id === id) {
-            item.exists = false;
-
-            break;
-          }
-        }
-
-        config.set("downloads.history", downloadHistory);
-
+      if (await downloads.markDownloadMissingIfGone(id, filePath)) {
         return;
       }
 


### PR DESCRIPTION
`downloads.openFile`, `downloads.showFileInFolder`, and `downloads.dragFile` each repeated the same 10-line "file missing → flip history entry → return" block. Extracted to `downloads.markDownloadMissingIfGone(id, filePath)` on the `Downloads` class, which returns `true` when the file is gone so callers can early-return.

## Test plan
- [ ] `bun types:ci` passes
- [ ] With a download whose file has been deleted, trigger Open, Show in Folder, and Drag — each should mark the history entry as missing and not attempt the action
- [ ] With a download whose file still exists, all three actions continue to work normally