### PR TITLE
add Accounts.findInstanceByGmailWebContentsId helper

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { AccountConfig } from "@meru/shared/schemas";
+import { BrowserWindow } from "electron";
 import { Account } from "./account";
 import { config } from "./config";
 import { licenseKey } from "./license-key";
@@ -146,6 +147,24 @@ class Accounts {
     }
 
     return selectedAccount;
+  }
+
+  findInstanceByGmailWebContentsId(webContentsId: number) {
+    for (const account of this.instances.values()) {
+      if (account.gmail.view.webContents.id === webContentsId) {
+        return account;
+      }
+    }
+  }
+
+  findComposeWindowByWebContentsId(webContentsId: number) {
+    for (const account of this.instances.values()) {
+      for (const window of account.windows) {
+        if (window instanceof BrowserWindow && window.webContents.id === webContentsId) {
+          return { account, window };
+        }
+      }
+    }
   }
 
   selectAccount(selectedAccountId: string) {

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 import type { AccountConfig } from "@meru/shared/schemas";
-import { BrowserWindow } from "electron";
 import { Account } from "./account";
 import { config } from "./config";
 import { licenseKey } from "./license-key";
@@ -153,16 +152,6 @@ class Accounts {
     for (const account of this.instances.values()) {
       if (account.gmail.view.webContents.id === webContentsId) {
         return account;
-      }
-    }
-  }
-
-  findComposeWindowByWebContentsId(webContentsId: number) {
-    for (const account of this.instances.values()) {
-      for (const window of account.windows) {
-        if (window instanceof BrowserWindow && window.webContents.id === webContentsId) {
-          return { account, window };
-        }
       }
     }
   }

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -345,31 +345,31 @@ class Ipc {
     });
 
     ipc.main.on("gmail.closeComposeWindow", (event) => {
-      const match = accounts.findComposeWindowByWebContentsId(event.sender.id);
+      for (const accountInstance of accounts.instances.values()) {
+        for (const window of accountInstance.windows) {
+          if (window instanceof BrowserWindow && window.webContents.id === event.sender.id) {
+            window.hide();
 
-      if (!match) {
-        return;
+            const browserWindowId = window.id;
+
+            window.once("closed", () => {
+              ipc.renderer.send(
+                accountInstance.gmail.view.webContents,
+                "gmail.dismissMessageSentNotification",
+                browserWindowId,
+              );
+            });
+
+            ipc.renderer.send(
+              accountInstance.gmail.view.webContents,
+              "gmail.showMessageSentNotification",
+              browserWindowId,
+            );
+
+            return;
+          }
+        }
       }
-
-      const { account: accountInstance, window } = match;
-
-      window.hide();
-
-      const browserWindowId = window.id;
-
-      window.once("closed", () => {
-        ipc.renderer.send(
-          accountInstance.gmail.view.webContents,
-          "gmail.dismissMessageSentNotification",
-          browserWindowId,
-        );
-      });
-
-      ipc.renderer.send(
-        accountInstance.gmail.view.webContents,
-        "gmail.showMessageSentNotification",
-        browserWindowId,
-      );
     });
 
     ipc.main.on("gmail.undoMessageSent", (_event, browserWindowId) => {

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -97,12 +97,12 @@ class Ipc {
     });
 
     this.main.on("gmail.setOutOfOffice", (event, outOfOffice) => {
-      for (const accountInstance of accounts.instances.values()) {
-        if (event.sender.id === accountInstance.gmail.view.webContents.id) {
-          accountInstance.gmail.store.setState({
-            outOfOffice,
-          });
-        }
+      const accountInstance = accounts.findInstanceByGmailWebContentsId(event.sender.id);
+
+      if (accountInstance) {
+        accountInstance.gmail.store.setState({
+          outOfOffice,
+        });
       }
     });
 
@@ -345,31 +345,31 @@ class Ipc {
     });
 
     ipc.main.on("gmail.closeComposeWindow", (event) => {
-      for (const accountInstance of accounts.instances.values()) {
-        for (const window of accountInstance.windows) {
-          if (window instanceof BrowserWindow && window.webContents.id === event.sender.id) {
-            window.hide();
+      const match = accounts.findComposeWindowByWebContentsId(event.sender.id);
 
-            const browserWindowId = window.id;
-
-            window.once("closed", () => {
-              ipc.renderer.send(
-                accountInstance.gmail.view.webContents,
-                "gmail.dismissMessageSentNotification",
-                browserWindowId,
-              );
-            });
-
-            ipc.renderer.send(
-              accountInstance.gmail.view.webContents,
-              "gmail.showMessageSentNotification",
-              browserWindowId,
-            );
-
-            return;
-          }
-        }
+      if (!match) {
+        return;
       }
+
+      const { account: accountInstance, window } = match;
+
+      window.hide();
+
+      const browserWindowId = window.id;
+
+      window.once("closed", () => {
+        ipc.renderer.send(
+          accountInstance.gmail.view.webContents,
+          "gmail.dismissMessageSentNotification",
+          browserWindowId,
+        );
+      });
+
+      ipc.renderer.send(
+        accountInstance.gmail.view.webContents,
+        "gmail.showMessageSentNotification",
+        browserWindowId,
+      );
     });
 
     ipc.main.on("gmail.undoMessageSent", (_event, browserWindowId) => {
@@ -385,12 +385,10 @@ class Ipc {
     });
 
     ipc.main.on("gmail.setUserEmail", (event, email) => {
-      for (const accountInstance of accounts.instances.values()) {
-        if (accountInstance.gmail.view.webContents.id === event.sender.id) {
-          accountInstance.gmail.userEmail = email;
+      const accountInstance = accounts.findInstanceByGmailWebContentsId(event.sender.id);
 
-          return;
-        }
+      if (accountInstance) {
+        accountInstance.gmail.userEmail = email;
       }
     });
 


### PR DESCRIPTION
`gmail.setOutOfOffice` and `gmail.setUserEmail` both iterated `accounts.instances.values()` to find the `Account` whose Gmail view webContents id matched `event.sender.id`. Extracted that into `Accounts.findInstanceByGmailWebContentsId`.

`gmail.closeComposeWindow` walked a nested `account.windows` loop with the same goal, but per CLAUDE.md §"Inline Single-Use Values" a helper called from exactly one site should be inlined — so its loop stays in the handler.

## Test plan
- [ ] `bun types:ci` passes
- [ ] `gmail.setOutOfOffice`: toggle out-of-office in Gmail; the store state reflects the change for the correct account
- [ ] `gmail.closeComposeWindow`: send a compose window; it hides and the inline "message sent" notification appears in the matching account view
- [ ] `gmail.setUserEmail`: add an account; the user email is set on the right `Gmail` instance