### PR TITLE
add ConfigSelectField and migrate settings pages

### DIFF
--- a/packages/renderer/components/config-select-field.tsx
+++ b/packages/renderer/components/config-select-field.tsx
@@ -1,0 +1,92 @@
+import type { Config } from "@meru/shared/types";
+import { Field, FieldContent, FieldDescription, FieldLabel } from "@meru/ui/components/field";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@meru/ui/components/select";
+import { useIsLicenseKeyValid } from "@/lib/hooks";
+import { useConfig, useConfigMutation } from "@meru/renderer-lib/react-query";
+import { restartRequiredToast } from "@/lib/toast";
+import { LicenseKeyRequiredFieldBadge } from "./license-key-required-field-badge";
+
+export function ConfigSelectField({
+  configKey,
+  label,
+  description,
+  items,
+  placeholder,
+  licenseKeyRequired,
+  disabled,
+  restartRequired,
+}: {
+  configKey: keyof Config;
+  label: string;
+  description: string;
+  items: { value: string; label: string }[];
+  placeholder: string;
+  licenseKeyRequired?: boolean;
+  disabled?: boolean;
+  restartRequired?: boolean;
+}) {
+  const { config } = useConfig();
+
+  const configMutation = useConfigMutation({
+    onSuccess: () => {
+      if (restartRequired) {
+        restartRequiredToast();
+      }
+    },
+  });
+
+  const isLicenseKeyValid = useIsLicenseKeyValid();
+
+  if (!config) {
+    return;
+  }
+
+  const value = config[configKey];
+
+  if (typeof value !== "string") {
+    throw new Error(`ConfigSelectField: Config key "${configKey}" is not a string`);
+  }
+
+  const isDisabled = disabled || (licenseKeyRequired && !isLicenseKeyValid);
+
+  return (
+    <Field>
+      <FieldContent>
+        <FieldLabel className="flex items-center gap-2">
+          {label}
+          {licenseKeyRequired && <LicenseKeyRequiredFieldBadge />}
+        </FieldLabel>
+        <FieldDescription>{description}</FieldDescription>
+      </FieldContent>
+      <Select
+        items={items}
+        value={value}
+        onValueChange={(newValue) => {
+          if (newValue) {
+            configMutation.mutate({
+              [configKey]: newValue,
+            });
+          }
+        }}
+        disabled={isDisabled}
+      >
+        <SelectTrigger>
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          {items.map(({ value, label }) => (
+            <SelectItem key={value} value={value}>
+              {label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </Field>
+  );
+}

--- a/packages/renderer/routes/settings/appearance.tsx
+++ b/packages/renderer/routes/settings/appearance.tsx
@@ -17,9 +17,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@meru/ui/components/select";
+import { ConfigSelectField } from "@/components/config-select-field";
 import { ConfigSwitchField } from "@/components/config-switch-field";
 import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
-import { useConfig, useConfigMutation } from "@meru/renderer-lib/react-query";
+import { useConfig } from "@meru/renderer-lib/react-query";
 import { restartRequiredToast } from "@/lib/toast";
 
 const themeItems = [
@@ -36,8 +37,6 @@ const systemTrayIconColorItems = [
 
 export function AppearanceSettings() {
   const { config } = useConfig();
-
-  const configMutation = useConfigMutation();
 
   if (!config) {
     return;
@@ -106,41 +105,14 @@ export function AppearanceSettings() {
           configKey="tray.enabled"
           restartRequired
         />
-        <Field>
-          <FieldContent>
-            <FieldLabel>Color</FieldLabel>
-            <FieldDescription>Choose the color of the system tray icon.</FieldDescription>
-          </FieldContent>
-          <Select
-            items={systemTrayIconColorItems}
-            value={config["tray.iconColor"]}
-            onValueChange={(value) => {
-              if (value) {
-                configMutation.mutate(
-                  {
-                    "tray.iconColor": value,
-                  },
-                  {
-                    onSuccess: () => {
-                      restartRequiredToast();
-                    },
-                  },
-                );
-              }
-            }}
-          >
-            <SelectTrigger>
-              <SelectValue placeholder="Select color" />
-            </SelectTrigger>
-            <SelectContent>
-              {systemTrayIconColorItems.map(({ value, label }) => (
-                <SelectItem key={value} value={value}>
-                  {label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </Field>
+        <ConfigSelectField
+          configKey="tray.iconColor"
+          label="Color"
+          description="Choose the color of the system tray icon."
+          items={systemTrayIconColorItems}
+          placeholder="Select color"
+          restartRequired
+        />
         {selectAccountWithUnreadField}
       </FieldSet>
     );

--- a/packages/renderer/routes/settings/gmail.tsx
+++ b/packages/renderer/routes/settings/gmail.tsx
@@ -10,20 +10,13 @@ import {
   FieldSeparator,
   FieldSet,
 } from "@meru/ui/components/field";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@meru/ui/components/select";
+import { ConfigSelectField } from "@/components/config-select-field";
 import { ConfigSwitchField } from "@/components/config-switch-field";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
 import { LicenseKeyRequiredFieldBadge } from "@/components/license-key-required-field-badge";
 import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
 import { useIsLicenseKeyValid } from "@/lib/hooks";
-import { useConfig, useConfigMutation } from "@meru/renderer-lib/react-query";
-import { restartRequiredToast } from "@/lib/toast";
+import { useConfig } from "@meru/renderer-lib/react-query";
 
 const unreadCountPreferenceItems = [
   { value: "first-section", label: "First Section Only" },
@@ -39,8 +32,6 @@ export function GmailSettings() {
   const isLicenseKeyValid = useIsLicenseKeyValid();
 
   const { config } = useConfig();
-
-  const configMutation = useConfigMutation();
 
   if (!config) {
     return;
@@ -129,85 +120,24 @@ export function GmailSettings() {
               restartRequired
               licenseKeyRequired
             />
-            <Field>
-              <FieldContent>
-                <FieldLabel className="flex items-center gap-2">
-                  Unread Count Preference <LicenseKeyRequiredFieldBadge />
-                </FieldLabel>
-                <FieldDescription>
-                  When using multiple inboxes, sets which sections contribute to the unread count
-                  shown on the app. Default combines all sections.
-                </FieldDescription>
-              </FieldContent>
-              <Select
-                items={unreadCountPreferenceItems}
-                value={config["gmail.unreadCountPreference"]}
-                onValueChange={(value) => {
-                  if (value) {
-                    configMutation.mutate(
-                      {
-                        "gmail.unreadCountPreference": value,
-                      },
-                      {
-                        onSuccess: restartRequiredToast,
-                      },
-                    );
-                  }
-                }}
-                disabled={!isLicenseKeyValid}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="Select unread count preference" />
-                </SelectTrigger>
-                <SelectContent>
-                  {unreadCountPreferenceItems.map(({ value, label }) => (
-                    <SelectItem key={value} value={value}>
-                      {label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </Field>
-            <Field>
-              <FieldContent>
-                <FieldLabel className="flex items-center gap-2">
-                  Categories to Monitor
-                  <LicenseKeyRequiredFieldBadge />
-                </FieldLabel>
-                <FieldDescription>
-                  If using an inbox with categories, choose which inbox categories are monitored for
-                  new email notifications and included in the unified inbox.
-                </FieldDescription>
-              </FieldContent>
-              <Select
-                items={inboxCategoriesToMonitorItems}
-                value={config["gmail.inboxCategoriesToMonitor"]}
-                onValueChange={(value) => {
-                  if (value) {
-                    configMutation.mutate(
-                      {
-                        "gmail.inboxCategoriesToMonitor": value,
-                      },
-                      {
-                        onSuccess: restartRequiredToast,
-                      },
-                    );
-                  }
-                }}
-                disabled={!isLicenseKeyValid}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="Select inbox categories to monitor" />
-                </SelectTrigger>
-                <SelectContent>
-                  {inboxCategoriesToMonitorItems.map(({ value, label }) => (
-                    <SelectItem key={value} value={value}>
-                      {label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </Field>
+            <ConfigSelectField
+              configKey="gmail.unreadCountPreference"
+              label="Unread Count Preference"
+              description="When using multiple inboxes, sets which sections contribute to the unread count shown on the app. Default combines all sections."
+              items={unreadCountPreferenceItems}
+              placeholder="Select unread count preference"
+              licenseKeyRequired
+              restartRequired
+            />
+            <ConfigSelectField
+              configKey="gmail.inboxCategoriesToMonitor"
+              label="Categories to Monitor"
+              description="If using an inbox with categories, choose which inbox categories are monitored for new email notifications and included in the unified inbox."
+              items={inboxCategoriesToMonitorItems}
+              placeholder="Select inbox categories to monitor"
+              licenseKeyRequired
+              restartRequired
+            />
           </FieldSet>
           <FieldSeparator />
           <FieldSet>

--- a/packages/renderer/routes/settings/verification-codes.tsx
+++ b/packages/renderer/routes/settings/verification-codes.tsx
@@ -1,23 +1,9 @@
-import {
-  Field,
-  FieldContent,
-  FieldDescription,
-  FieldGroup,
-  FieldLabel,
-} from "@meru/ui/components/field";
+import { FieldGroup } from "@meru/ui/components/field";
+import { ConfigSelectField } from "@/components/config-select-field";
 import { ConfigSwitchField } from "@/components/config-switch-field";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
 import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@meru/ui/components/select";
-import { useConfig, useConfigMutation } from "@meru/renderer-lib/react-query";
-import { useIsLicenseKeyValid } from "@/lib/hooks";
-import { Badge } from "@meru/ui/components/badge";
+import { useConfig } from "@meru/renderer-lib/react-query";
 
 const verificationCodeConfidenceItems = [
   { value: "high", label: "High" },
@@ -26,9 +12,6 @@ const verificationCodeConfidenceItems = [
 
 export function VerificationCodesSettings() {
   const { config } = useConfig();
-  const configMutation = useConfigMutation();
-
-  const isLicenseKeyValid = useIsLicenseKeyValid();
 
   if (!config) {
     return;
@@ -49,41 +32,14 @@ export function VerificationCodesSettings() {
             configKey="verificationCodes.autoCopy"
             licenseKeyRequired
           />
-          <Field>
-            <FieldContent>
-              <FieldLabel className="flex items-center gap-2">
-                Verification Code Detection Confidence
-                {!isLicenseKeyValid && <Badge variant="secondary">Meru Pro Required</Badge>}
-              </FieldLabel>
-              <FieldDescription>
-                Choose the confidence level for detecting verification codes. Medium may result in
-                false positives, while High checks for explicit keywords, but may miss some codes.
-              </FieldDescription>
-            </FieldContent>
-            <Select
-              items={verificationCodeConfidenceItems}
-              value={config["verificationCodes.confidence"]}
-              onValueChange={(value) => {
-                if (value) {
-                  configMutation.mutate({
-                    "verificationCodes.confidence": value,
-                  });
-                }
-              }}
-              disabled={!isLicenseKeyValid}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Select confidence" />
-              </SelectTrigger>
-              <SelectContent>
-                {verificationCodeConfidenceItems.map(({ value, label }) => (
-                  <SelectItem key={value} value={value}>
-                    {label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </Field>
+          <ConfigSelectField
+            configKey="verificationCodes.confidence"
+            label="Verification Code Detection Confidence"
+            description="Choose the confidence level for detecting verification codes. Medium may result in false positives, while High checks for explicit keywords, but may miss some codes."
+            items={verificationCodeConfidenceItems}
+            placeholder="Select confidence"
+            licenseKeyRequired
+          />
           <ConfigSwitchField
             label="Automatically Mark Email as Read After Copying Verification Code"
             description="Email containing verification code will be automatically marked as read


### PR DESCRIPTION
Mirrors the existing `ConfigSwitchField` pattern for config-bound `Select` inputs. Each migrated call site used the same ~20-line scaffold — items mapped twice, truthy-value guard, `configMutation.mutate`, license-key disabled state, optional `restartRequiredToast`.

Migrated the four call sites that match the standard pattern:
- `gmail.tsx` — `gmail.unreadCountPreference`, `gmail.inboxCategoriesToMonitor`
- `appearance.tsx` — `tray.iconColor`
- `verification-codes.tsx` — `verificationCodes.confidence`

Left two selects alone because they don't fit the standard shape:
- `appearance.tsx` Theme select — uses `ipc.main.send("theme.setTheme")` instead of `configMutation.mutate`
- `notifications.tsx` Sound select — calls `playNotificationSound` as a side effect on change and appends an extra `<SelectItem value="system">` after a separator

## Test plan
- [ ] `bun types:ci` passes
- [ ] Settings → Gmail: change both Unread Count Preference and Categories to Monitor; config persists and the restart-required toast appears
- [ ] Settings → Appearance (non-macOS): change System Tray Icon → Color; config persists and restart-required toast appears
- [ ] Settings → Verification Codes: change Confidence; config persists (no toast expected)
- [ ] Without a license, all four selects are disabled where they were previously (Gmail's two and Verification Code's one); appearance tray color remains enabled as before