### PR TITLE
extract loadRenderer and getPreloadPath helpers

### DIFF
--- a/packages/app/account.ts
+++ b/packages/app/account.ts
@@ -1,5 +1,4 @@
-import path from "node:path";
-import { is, platform } from "@electron-toolkit/utils";
+import { platform } from "@electron-toolkit/utils";
 import { GOOGLE_MEET_URL } from "@meru/shared/constants";
 import type { AccountConfig } from "@meru/shared/schemas";
 import type { SelectedDesktopSource } from "@meru/shared/types";
@@ -8,7 +7,6 @@ import {
   BrowserWindow,
   type IpcMainEvent,
   ipcMain,
-  nativeTheme,
   type Session,
   session,
   type WebContentsView,
@@ -16,6 +14,7 @@ import {
 import { blocker } from "./blocker";
 import { config } from "./config";
 import { Gmail } from "./gmail";
+import { getPreloadPath, loadRenderer } from "./lib/window";
 import { licenseKey } from "./license-key";
 
 export class Account {
@@ -108,7 +107,7 @@ export class Account {
           resizable: false,
           autoHideMenuBar: true,
           webPreferences: {
-            preload: path.join(__dirname, "preload-renderer.js"),
+            preload: getPreloadPath("renderer"),
           },
         });
 
@@ -136,24 +135,11 @@ export class Account {
 
         desktopSourcesWindow.once(windowEvent, windowListener);
 
-        const searchParams = new URLSearchParams();
-
-        searchParams.set("darkMode", nativeTheme.shouldUseDarkColors ? "true" : "false");
-
-        if (is.dev) {
-          desktopSourcesWindow.webContents.loadURL(
-            `http://localhost:3001/?${searchParams}#desktop-sources`,
-          );
-
-          desktopSourcesWindow.webContents.openDevTools({
-            mode: "detach",
-          });
-        } else {
-          desktopSourcesWindow.webContents.loadFile(
-            path.join("build-js", "renderer-popup", "index.html"),
-            { hash: "desktop-sources", search: searchParams.toString() },
-          );
-        }
+        loadRenderer(desktopSourcesWindow, {
+          renderer: "popup",
+          port: 3001,
+          hash: "desktop-sources",
+        });
       },
       { useSystemPicker: config.get("screenShare.useSystemPicker") },
     );

--- a/packages/app/downloads.ts
+++ b/packages/app/downloads.ts
@@ -2,15 +2,15 @@ import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { ms } from "@meru/shared/ms";
 import type { DownloadItem } from "@meru/shared/types";
-import { nativeTheme, shell, WebContentsView } from "electron";
+import { shell, WebContentsView } from "electron";
 import electronDl from "electron-dl";
 import { config } from "@/config";
 import { createNotification } from "@/notifications";
 import { ipc } from "./ipc";
 import { main } from "./main";
-import { is } from "@electron-toolkit/utils";
 import { APP_TITLEBAR_HEIGHT, BASE_SPACING } from "@meru/shared/constants";
 import { fileExists } from "./lib/fs";
+import { getPreloadPath, loadRenderer } from "./lib/window";
 
 class Downloads {
   recentDownloadHistoryPopup: WebContentsView | null = null;
@@ -143,29 +143,15 @@ class Downloads {
 
     this.recentDownloadHistoryPopup = new WebContentsView({
       webPreferences: {
-        preload: path.join(__dirname, "preload-renderer.js"),
+        preload: getPreloadPath("renderer"),
       },
     });
 
-    const searchParams = new URLSearchParams();
-
-    searchParams.set("darkMode", nativeTheme.shouldUseDarkColors ? "true" : "false");
-
-    const hash = "recent-download-history";
-
-    if (is.dev) {
-      this.recentDownloadHistoryPopup.webContents.loadURL(
-        `http://localhost:3001/?${searchParams}#${hash}`,
-      );
-    } else {
-      this.recentDownloadHistoryPopup.webContents.loadFile(
-        path.join("build-js", "renderer-popup", "index.html"),
-        {
-          hash,
-          search: searchParams.toString(),
-        },
-      );
-    }
+    loadRenderer(this.recentDownloadHistoryPopup, {
+      renderer: "popup",
+      port: 3001,
+      hash: "recent-download-history",
+    });
 
     main.window.contentView.addChildView(this.recentDownloadHistoryPopup);
 

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -24,7 +24,7 @@ import { appTray } from "@/tray";
 import gmailCSS from "./gmail.css";
 import meruCSS from "./meru.css";
 import { log } from "@/lib/log";
-import { getCascadedWindowBounds } from "@/lib/window";
+import { getCascadedWindowBounds, getPreloadPath } from "@/lib/window";
 import { xmlParser } from "@/lib/xml";
 import z from "zod";
 import { createNotification, isWithinNotificationTimes } from "@/notifications";
@@ -36,8 +36,6 @@ export const GMAIL_USER_STYLES_PATH = path.join(app.getPath("userData"), "gmail-
 const GMAIL_USER_STYLES: string | null = fs.existsSync(GMAIL_USER_STYLES_PATH)
   ? fs.readFileSync(GMAIL_USER_STYLES_PATH, "utf-8")
   : null;
-
-const GMAIL_PRELOAD_PATH = path.join(__dirname, "preload-gmail.js");
 
 const inboxFeedEntryAuthorSchema = z.object({
   name: z.coerce.string(),
@@ -275,7 +273,7 @@ export class Gmail extends GoogleApp {
       session,
       webContentsViewOptions: {
         webPreferences: {
-          preload: GMAIL_PRELOAD_PATH,
+          preload: getPreloadPath("gmail"),
           additionalArguments,
         },
       },

--- a/packages/app/google-app.ts
+++ b/packages/app/google-app.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { is } from "@electron-toolkit/utils";
 import { accountColorsMap } from "@meru/shared/accounts";
 import { APP_TITLEBAR_HEIGHT, GOOGLE_ACCOUNTS_URL } from "@meru/shared/constants";
@@ -23,7 +22,7 @@ import { accounts } from "./accounts";
 import { config } from "./config";
 import { setupWindowContextMenu } from "./context-menu";
 import { ipc } from "./ipc";
-import { getCascadedWindowBounds } from "./lib/window";
+import { getCascadedWindowBounds, getPreloadPath } from "./lib/window";
 import { licenseKey } from "./license-key";
 import { main } from "./main";
 import { openExternalUrl } from "./url";
@@ -426,7 +425,7 @@ export class GoogleApp {
           autoHideMenuBar: true,
           webPreferences: {
             session: this.session,
-            preload: path.join(__dirname, "preload-google-app.js"),
+            preload: getPreloadPath("google-app"),
           },
         };
 

--- a/packages/app/lib/window.ts
+++ b/packages/app/lib/window.ts
@@ -1,4 +1,6 @@
-import { BrowserWindow, screen } from "electron";
+import path from "node:path";
+import { is } from "@electron-toolkit/utils";
+import { BrowserWindow, nativeTheme, screen, WebContentsView } from "electron";
 
 const CASCADE_OFFSET = 30;
 
@@ -26,4 +28,41 @@ export function getCascadedWindowBounds({ width, height }: { width: number; heig
   }
 
   return { x, y, width, height };
+}
+
+export function getPreloadPath(name: string) {
+  return path.join(__dirname, `preload-${name}.js`);
+}
+
+type LoadRendererOptions = {
+  renderer: string;
+  port: number;
+  searchParams?: URLSearchParams;
+  hash?: string;
+};
+
+export function loadRenderer(
+  window: BrowserWindow | WebContentsView,
+  options: LoadRendererOptions,
+) {
+  const { renderer, port, hash } = options;
+
+  const searchParams = options.searchParams ?? new URLSearchParams();
+
+  searchParams.set("darkMode", nativeTheme.shouldUseDarkColors ? "true" : "false");
+
+  const rendererName = `renderer-${renderer}`;
+
+  if (is.dev) {
+    const hashSuffix = hash ? `#${hash}` : "";
+
+    window.webContents.loadURL(`http://localhost:${port}/?${searchParams.toString()}${hashSuffix}`);
+
+    window.webContents.openDevTools({ mode: "detach" });
+  } else {
+    window.webContents.loadFile(path.join("build-js", rendererName, "index.html"), {
+      search: searchParams.toString(),
+      ...(hash ? { hash } : {}),
+    });
+  }
 }

--- a/packages/app/main.ts
+++ b/packages/app/main.ts
@@ -1,10 +1,11 @@
 import path from "node:path";
-import { is, platform } from "@electron-toolkit/utils";
+import { platform } from "@electron-toolkit/utils";
 import { APP_TITLEBAR_HEIGHT } from "@meru/shared/constants";
 import { app, BrowserWindow, nativeTheme, screen } from "electron";
 import { accounts } from "@/accounts";
 import { config, DEFAULT_WINDOW_STATE_BOUNDS } from "@/config";
 import { isLinuxWindowControlsEnabled } from "@/lib/linux";
+import { getPreloadPath, loadRenderer } from "@/lib/window";
 import { appState } from "@/state";
 import { openExternalUrl } from "@/url";
 import { ipc } from "./ipc";
@@ -31,8 +32,6 @@ class Main {
   loadURL() {
     const searchParams = new URLSearchParams();
 
-    searchParams.set("darkMode", nativeTheme.shouldUseDarkColors ? "true" : "false");
-
     searchParams.set(
       "accounts",
       JSON.stringify(
@@ -52,17 +51,11 @@ class Main {
       searchParams.set("trialDaysLeft", JSON.stringify(trial.daysLeft));
     }
 
-    if (is.dev) {
-      this.window.webContents.loadURL(`http://localhost:3000/?${searchParams.toString()}`);
-
-      this.window.webContents.openDevTools({
-        mode: "detach",
-      });
-    } else {
-      this.window.webContents.loadFile(path.join("build-js", "renderer-main", "index.html"), {
-        search: searchParams.toString(),
-      });
-    }
+    loadRenderer(this.window, {
+      renderer: "main",
+      port: 3000,
+      searchParams,
+    });
   }
 
   getTitlebarOverlayOptions() {
@@ -106,7 +99,7 @@ class Main {
           : false,
       darkTheme: nativeTheme.shouldUseDarkColors,
       webPreferences: {
-        preload: path.join(__dirname, "preload-renderer.js"),
+        preload: getPreloadPath("renderer"),
       },
       icon: platform.isLinux ? path.join(__dirname, "..", "static", "Icon.png") : undefined,
     });


### PR DESCRIPTION
## Summary

Pulls two small helpers out of `packages/app/lib/window.ts` so the dev/prod renderer-loading dance and the `path.join(__dirname, "preload-*.js")` pattern stop repeating across the main process.

- **`loadRenderer(window, { renderer, port, searchParams?, hash? })`** — unifies the `is.dev ? loadURL : loadFile` branching used in `main.ts`, `account.ts`, and `downloads.ts`. Auto-injects the `darkMode` search param so callers drop that boilerplate. Accepts a `BrowserWindow | WebContentsView` directly (both have `webContents`) so callers don't reach for `.webContents`. Always opens devtools in dev.
- **`getPreloadPath(name)`** — wraps `path.join(__dirname, \`preload-${name}.js\`)`. Replaces the inlined calls in `main.ts`, `account.ts`, `downloads.ts`, `google-app.ts`, and drops the local `GMAIL_PRELOAD_PATH` constant in `gmail/index.ts`.

Net `+68/-67` lines across 6 files.

This is prep work split off from a larger `GoogleAppWindow` branch to keep that review scope small and focused — landing these helpers first lets the follow-up consume them.

## Test plan

- [x] `bun types:ci` passes across all 8 packages
- [x] Pre-commit hook (oxfmt + oxlint) clean
- [ ] Main window loads Gmail in dev and prod (exercises migrated `main.ts` path)
- [ ] Desktop-sources picker opens when triggering a screen share in a Meet call (exercises migrated `account.ts` path)
- [ ] Recent downloads popup opens from the downloads button and closes on blur (exercises migrated `downloads.ts` path)
- [ ] Gmail preload still attaches (exercises migrated `gmail/index.ts` path)
- [ ] Google App windows spawned from Gmail still load (exercises migrated `google-app.ts` path)

https://claude.ai/code/session_01BBFrzPtnKeDjBBij2c4TyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBFrzPtnKeDjBBij2c4TyA)_