### PR TITLE
split isLinuxWindowControlsEnabled into init + sync getter

### DIFF
--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -6,6 +6,7 @@ import { blocker } from "@/blocker";
 import { config } from "@/config";
 import { downloads } from "@/downloads";
 import { ipc } from "@/ipc";
+import { initLinuxWindowControls } from "@/lib/linux";
 import { licenseKey } from "@/license-key";
 import { main } from "@/main";
 import { appMenu } from "@/menu";
@@ -98,7 +99,9 @@ async function init() {
 
   accounts.init();
 
-  await main.init();
+  await initLinuxWindowControls();
+
+  main.init();
 
   main.loadURL();
 

--- a/packages/app/lib/linux.ts
+++ b/packages/app/lib/linux.ts
@@ -7,7 +7,7 @@ import { promisify } from "node:util";
 
 const execFile = promisify(childProcess.execFile);
 
-let cachedIsLinuxWindowControlsEnabled: boolean | null = null;
+let linuxWindowControlsEnabled: boolean | null = null;
 
 async function getGtkDecorationLayout() {
   try {
@@ -46,19 +46,25 @@ async function getGtkDecorationLayout() {
   return null;
 }
 
-export async function isLinuxWindowControlsEnabled() {
+export async function initLinuxWindowControls() {
   if (!platform.isLinux) {
-    throw new Error("isLinuxWindowControlsEnabled is only supported on Linux");
-  }
-
-  if (typeof cachedIsLinuxWindowControlsEnabled === "boolean") {
-    return cachedIsLinuxWindowControlsEnabled;
+    return;
   }
 
   const gtkDecorationLayout = await getGtkDecorationLayout();
 
-  cachedIsLinuxWindowControlsEnabled =
+  linuxWindowControlsEnabled =
     gtkDecorationLayout === null ? true : /close|minimize|maximize/.test(gtkDecorationLayout);
+}
 
-  return cachedIsLinuxWindowControlsEnabled;
+export function isLinuxWindowControlsEnabled() {
+  if (!platform.isLinux) {
+    throw new Error("isLinuxWindowControlsEnabled is only supported on Linux");
+  }
+
+  if (linuxWindowControlsEnabled === null) {
+    throw new Error("initLinuxWindowControls must be called first");
+  }
+
+  return linuxWindowControlsEnabled;
 }

--- a/packages/app/main.ts
+++ b/packages/app/main.ts
@@ -66,13 +66,13 @@ class Main {
     };
   }
 
-  async updateTitlebarOverlay() {
-    if (!platform.isLinux || (await isLinuxWindowControlsEnabled())) {
+  updateTitlebarOverlay() {
+    if (!platform.isLinux || isLinuxWindowControlsEnabled()) {
       this.window.setTitleBarOverlay(this.getTitlebarOverlayOptions());
     }
   }
 
-  async init() {
+  init() {
     const lastWindowState = config.get("window.lastState");
     const restrictWindowMinimumSize = config.get("window.restrictMinimumSize");
 
@@ -94,7 +94,7 @@ class Main {
       show: false,
       titleBarStyle: platform.isMacOS ? "hiddenInset" : "hidden",
       titleBarOverlay:
-        !platform.isLinux || (await isLinuxWindowControlsEnabled())
+        !platform.isLinux || isLinuxWindowControlsEnabled()
           ? this.getTitlebarOverlayOptions()
           : false,
       darkTheme: nativeTheme.shouldUseDarkColors,


### PR DESCRIPTION
## Summary

Splits the async `isLinuxWindowControlsEnabled` helper in `packages/app/lib/linux.ts` into an explicit init step plus a synchronous getter, so callers that need the value during window construction don't have to be async.

- **`initLinuxWindowControls()`** (new, async) — runs the GTK decoration-layout check once at app startup. No-op on non-Linux.
- **`isLinuxWindowControlsEnabled()`** — now synchronous. Returns the cached result. Throws on non-Linux (unchanged) and throws if `initLinuxWindowControls` hasn't been called first.

Wires the init into `packages/app/index.ts` right before `main.init()`, and drops the `await`s in `main.ts`. `main.init` and `main.updateTitlebarOverlay` become synchronous as a result.

Prep work split off from a larger `GoogleAppWindow` branch — that branch has a new window class that wants to spread titlebar options into `new BrowserWindow({ ... })` synchronously, which requires this split. Landing this first keeps that PR's review scope small.

## Test plan

- [x] `bun types:ci` passes across all 8 packages
- [x] Pre-commit hook (oxfmt + oxlint) clean
- [ ] Main window opens normally on macOS (non-Linux path, no-op init)
- [ ] Main window opens normally on Linux with GNOME-style window controls
- [ ] Main window opens normally on Linux without window controls (no overlay)
- [ ] Toggling dark/light mode still calls `updateTitlebarOverlay` correctly
- [ ] Windows build: titleBarOverlay still renders with correct colors

https://claude.ai/code/session_01BBFrzPtnKeDjBBij2c4TyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBFrzPtnKeDjBBij2c4TyA)_