### PR TITLE
add common BrowserWindow helpers to lib/window

### DIFF
--- a/packages/app/account.ts
+++ b/packages/app/account.ts
@@ -14,7 +14,7 @@ import {
 import { blocker } from "./blocker";
 import { config } from "./config";
 import { Gmail } from "./gmail";
-import { getPreloadPath, loadRenderer } from "./lib/window";
+import { createBrowserWindow, getPreloadPath, loadRenderer } from "./lib/window";
 import { licenseKey } from "./license-key";
 
 export class Account {
@@ -99,7 +99,7 @@ export class Account {
           return;
         }
 
-        const desktopSourcesWindow = new BrowserWindow({
+        const desktopSourcesWindow = createBrowserWindow({
           title: "Choose what to share",
           parent: googleMeetApp instanceof BrowserWindow ? googleMeetApp : undefined,
           width: 576,

--- a/packages/app/lib/window.ts
+++ b/packages/app/lib/window.ts
@@ -1,6 +1,14 @@
 import path from "node:path";
-import { is } from "@electron-toolkit/utils";
-import { BrowserWindow, nativeTheme, screen, WebContentsView } from "electron";
+import { is, platform } from "@electron-toolkit/utils";
+import { APP_TITLEBAR_HEIGHT } from "@meru/shared/constants";
+import {
+  BrowserWindow,
+  type BrowserWindowConstructorOptions,
+  nativeTheme,
+  screen,
+  WebContentsView,
+} from "electron";
+import { isLinuxWindowControlsEnabled } from "./linux";
 
 const CASCADE_OFFSET = 30;
 
@@ -32,6 +40,45 @@ export function getCascadedWindowBounds({ width, height }: { width: number; heig
 
 export function getPreloadPath(name: string) {
   return path.join(__dirname, `preload-${name}.js`);
+}
+
+export function getTitleBarOptions() {
+  const titleBarOverlay =
+    !platform.isLinux || isLinuxWindowControlsEnabled()
+      ? {
+          color: nativeTheme.shouldUseDarkColors ? "#0a0a0a" : "#ffffff",
+          symbolColor: nativeTheme.shouldUseDarkColors ? "#fafafa" : "#0a0a0a",
+          height: APP_TITLEBAR_HEIGHT - 1,
+        }
+      : false;
+
+  return {
+    titleBarStyle: platform.isMacOS ? ("hiddenInset" as const) : ("hidden" as const),
+    titleBarOverlay,
+  };
+}
+
+export function getCommonBrowserWindowOptions() {
+  return {
+    ...getTitleBarOptions(),
+    darkTheme: nativeTheme.shouldUseDarkColors,
+    webPreferences: {
+      preload: getPreloadPath("renderer"),
+    },
+  };
+}
+
+export function createBrowserWindow(options: BrowserWindowConstructorOptions) {
+  const browserWindow = new BrowserWindow({
+    show: false,
+    ...options,
+  });
+
+  browserWindow.once("ready-to-show", () => {
+    browserWindow.show();
+  });
+
+  return browserWindow;
 }
 
 type LoadRendererOptions = {

--- a/packages/app/main.ts
+++ b/packages/app/main.ts
@@ -1,11 +1,9 @@
 import path from "node:path";
 import { platform } from "@electron-toolkit/utils";
-import { APP_TITLEBAR_HEIGHT } from "@meru/shared/constants";
-import { app, BrowserWindow, nativeTheme, screen } from "electron";
+import { app, BrowserWindow, screen } from "electron";
 import { accounts } from "@/accounts";
 import { config, DEFAULT_WINDOW_STATE_BOUNDS } from "@/config";
-import { isLinuxWindowControlsEnabled } from "@/lib/linux";
-import { getPreloadPath, loadRenderer } from "@/lib/window";
+import { getCommonBrowserWindowOptions, getTitleBarOptions, loadRenderer } from "@/lib/window";
 import { appState } from "@/state";
 import { openExternalUrl } from "@/url";
 import { ipc } from "./ipc";
@@ -58,18 +56,14 @@ class Main {
     });
   }
 
-  getTitlebarOverlayOptions() {
-    return {
-      color: nativeTheme.shouldUseDarkColors ? "#0a0a0a" : "#ffffff",
-      symbolColor: nativeTheme.shouldUseDarkColors ? "#fafafa" : "#0a0a0a",
-      height: APP_TITLEBAR_HEIGHT - 1,
-    };
-  }
-
   updateTitlebarOverlay() {
-    if (!platform.isLinux || isLinuxWindowControlsEnabled()) {
-      this.window.setTitleBarOverlay(this.getTitlebarOverlayOptions());
+    const { titleBarOverlay } = getTitleBarOptions();
+
+    if (typeof titleBarOverlay === "boolean") {
+      return;
     }
+
+    this.window.setTitleBarOverlay(titleBarOverlay);
   }
 
   init() {
@@ -92,15 +86,7 @@ class Main {
       x: lastWindowState.bounds.x,
       y: lastWindowState.bounds.y,
       show: false,
-      titleBarStyle: platform.isMacOS ? "hiddenInset" : "hidden",
-      titleBarOverlay:
-        !platform.isLinux || isLinuxWindowControlsEnabled()
-          ? this.getTitlebarOverlayOptions()
-          : false,
-      darkTheme: nativeTheme.shouldUseDarkColors,
-      webPreferences: {
-        preload: getPreloadPath("renderer"),
-      },
+      ...getCommonBrowserWindowOptions(),
       icon: platform.isLinux ? path.join(__dirname, "..", "static", "Icon.png") : undefined,
     });
 


### PR DESCRIPTION
## Summary

Pulls three helpers out of `packages/app/lib/window.ts` so the titlebar + darkTheme + preload + ready-to-show boilerplate stops repeating across BrowserWindow constructions.

- **`getTitleBarOptions()`** — returns `{ titleBarStyle, titleBarOverlay }`. Wraps the "hiddenInset on macOS, hidden+overlay elsewhere, opt out when Linux has no GTK controls" logic so callers just spread it.
- **`getCommonBrowserWindowOptions()`** — branded-chrome defaults: `...getTitleBarOptions()` + `darkTheme` + renderer preload. For spread into `new BrowserWindow({ ... })`.
- **`createBrowserWindow(options)`** — constructs a `BrowserWindow` with `show: false` and a `ready-to-show` listener that calls `show()`. Avoids the flicker where a freshly constructed window renders empty for a frame before the renderer paints.

Migrations:
- **`main.ts`** — drops the local `getTitlebarOverlayOptions` method and the inline 9-line titleBar/darkTheme/preload block in `init()` in favor of `...getCommonBrowserWindowOptions()`. `updateTitlebarOverlay` reads overlay off `getTitleBarOptions()` and becomes synchronous. `init` becomes synchronous too. Keeps its local `show: false` + custom `ready-to-show` (gated on `shouldLaunchMinimized`, calls `show()` with dock handling) since that doesn't fit the factory shape.
- **`account.ts`** — desktop-sources picker switches to `createBrowserWindow(...)` — it previously showed immediately and flickered while its renderer loaded.

Prep work split off from a larger `GoogleAppWindow` branch — landing these helpers first lets that PR consume them without bundling the infra refactor into a feature review.

## Test plan

- [x] `bun types:ci` passes across all 8 packages
- [x] Pre-commit hook (oxfmt + oxlint) clean
- [ ] Main window opens normally on macOS with `hiddenInset` titlebar (traffic lights visible)
- [ ] Main window opens normally on Windows with overlay showing the window controls
- [ ] Main window opens normally on Linux with and without GTK window controls
- [ ] Toggling dark/light mode still calls `updateTitlebarOverlay` and updates overlay colors
- [ ] Desktop-sources picker opens when triggering a screen share in a Meet call; no longer flickers on load

https://claude.ai/code/session_01BBFrzPtnKeDjBBij2c4TyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBFrzPtnKeDjBBij2c4TyA)_