### PR TITLE
rename GoogleApp to GoogleAppLegacy

### DIFF
--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -16,7 +16,7 @@ import { createStore } from "zustand/vanilla";
 import { accounts } from "@/accounts";
 import { config } from "@/config";
 import { setupWindowContextMenu } from "@/context-menu";
-import { GoogleApp, type GoogleAppOptions } from "@/google-app";
+import { GoogleAppLegacy, type GoogleAppLegacyOptions } from "@/google-app-legacy";
 import { ipc } from "@/ipc";
 import { licenseKey } from "@/license-key";
 import { main } from "@/main";
@@ -189,7 +189,7 @@ function extractVerificationCode(texts: string[]) {
   return null;
 }
 
-export class Gmail extends GoogleApp {
+export class Gmail extends GoogleAppLegacy {
   userEmail: string | null = null;
 
   unreadCountEnabled = true;
@@ -226,7 +226,7 @@ export class Gmail extends GoogleApp {
     unreadCountEnabled: boolean;
     unifiedInboxEnabled: boolean;
     delegatedAccountId: string | null;
-  } & Omit<GoogleAppOptions, "url">) {
+  } & Omit<GoogleAppLegacyOptions, "url">) {
     const additionalArguments: string[] = [];
 
     if (config.get("gmail.hideGmailLogo")) {

--- a/packages/app/google-app-legacy.ts
+++ b/packages/app/google-app-legacy.ts
@@ -38,19 +38,19 @@ const SUPPORTED_GOOGLE_APPS_URL_REGEXP = new RegExp(
 
 const WINDOW_OPEN_DOWNLOAD_URL_WHITELIST = [/chat\.google\.com\/u\/\d\/api\/get_attachment_url/];
 
-type GoogleAppHooks = {
+type GoogleAppLegacyHooks = {
   beforeLoadUrl?: ((view: WebContentsView) => void)[];
 };
 
-export type GoogleAppOptions = {
+export type GoogleAppLegacyOptions = {
   accountId: string;
   url: string;
   session: Session;
   webContentsViewOptions?: WebContentsViewConstructorOptions;
-  hooks?: GoogleAppHooks;
+  hooks?: GoogleAppLegacyHooks;
 };
 
-export class GoogleApp {
+export class GoogleAppLegacy {
   accountId: string;
 
   url: string;
@@ -61,7 +61,7 @@ export class GoogleApp {
 
   webContentsViewOptions: WebContentsViewConstructorOptions | undefined;
 
-  hooks: GoogleAppHooks = {};
+  hooks: GoogleAppLegacyHooks = {};
 
   private _view: WebContentsView | undefined;
 
@@ -93,7 +93,7 @@ export class GoogleApp {
     })),
   );
 
-  constructor({ accountId, url, session, webContentsViewOptions, hooks }: GoogleAppOptions) {
+  constructor({ accountId, url, session, webContentsViewOptions, hooks }: GoogleAppLegacyOptions) {
     this.accountId = accountId;
 
     this.url = url;


### PR DESCRIPTION
## Summary

Frees the `GoogleApp` name for an upcoming new implementation that wraps each Google App in its own `BrowserWindow` with a toolbar (back/forward/home/open-external). The existing class stays the production path for now — a follow-up PR introduces the new `GoogleApp`, and a later one migrates the legacy spawn path onto it.

- `packages/app/google-app.ts` → `packages/app/google-app-legacy.ts` (git rename, 98% similarity)
- `class GoogleApp` → `class GoogleAppLegacy`
- `type GoogleAppOptions` → `type GoogleAppLegacyOptions`
- `type GoogleAppHooks` → `type GoogleAppLegacyHooks`
- `Gmail extends GoogleApp` → `Gmail extends GoogleAppLegacy` in `packages/app/gmail/index.ts`

Shared types/values that happen to contain "GoogleApp" (`SupportedGoogleApp`, `supportedGoogleApps`, `GoogleAppIcon`, `GoogleAppsPinnedApp`, the `openGoogleApp` method, local `matchedSupportedGoogleApp`/`isGoogleAppEnabledToOpenInApp`) are unchanged — they refer to the concept of a supported Google app (Calendar, Docs, Meet, etc.), not the class.

Prep work split off from a larger GoogleAppWindow branch so that follow-up can introduce `GoogleApp` without a confusing drive-by rename.

## Test plan

- [x] `bun types:ci` passes across all 8 packages
- [x] Pre-commit hook (oxfmt + oxlint) clean
- [ ] Gmail loads normally (Gmail class extends GoogleAppLegacy)
- [ ] Opening a supported Google app (Calendar, Docs, Meet) from Gmail still spawns a window via the legacy path
- [ ] Meet global shortcuts and power-save blocker still trigger on Meet windows
- [ ] `Gmail compose` window still opens via the legacy `setWindowOpenHandler`

https://claude.ai/code/session_01BBFrzPtnKeDjBBij2c4TyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBFrzPtnKeDjBBij2c4TyA)_