### PR TITLE
drop redundant @source ui pattern from renderer globals.css

### DIFF
--- a/packages/renderer-main/globals.css
+++ b/packages/renderer-main/globals.css
@@ -3,7 +3,6 @@
 
 @plugin "@tailwindcss/typography";
 
-@source "../ui/**/*.{ts,tsx}";
 @source "../shared/**/*.{ts,tsx}";
 
 @utility draggable {

--- a/packages/renderer-popup/globals.css
+++ b/packages/renderer-popup/globals.css
@@ -1,5 +1,4 @@
 @import "sonner/dist/styles.css";
 @import "../ui/styles/globals.css";
 
-@source "../ui/**/*.{ts,tsx}";
 @source "../shared/**/*.{ts,tsx}";


### PR DESCRIPTION
## Summary

Each renderer package's `globals.css` imports `../ui/styles/globals.css`, which already declares `@source "../**/*.{ts,tsx}"`. Relative to `packages/ui/styles/`, that resolves to `packages/ui/**/*.{ts,tsx}` — the exact same tree the renderer-local `@source "../ui/**/*.{ts,tsx}"` was scanning. Drop the duplicate from both renderers.

The `@source "../shared/**/*.{ts,tsx}"` line stays because the shared UI globals.css only scans within `packages/ui/`, not `packages/shared/`.

Found while reviewing the new renderer package in a follow-up branch — applying it upstream first so it covers the existing renderers.

## Test plan

- [x] `bun types:ci` passes across all 8 packages
- [x] Pre-commit hook (oxfmt + oxlint) clean
- [ ] `bun run dev` — main window still gets Tailwind classes used only in `packages/ui/components/*.tsx` (e.g. a button component's default classes render with proper styling)
- [ ] Renderer-popup routes (desktop-sources picker, recent-downloads popup) still styled correctly

https://claude.ai/code/session_01BBFrzPtnKeDjBBij2c4TyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBFrzPtnKeDjBBij2c4TyA)_