### PR TITLE
move draggable app-region utilities to shared ui globals

### DIFF
--- a/packages/renderer-main/globals.css
+++ b/packages/renderer-main/globals.css
@@ -4,11 +4,3 @@
 @plugin "@tailwindcss/typography";
 
 @source "../shared/**/*.{ts,tsx}";
-
-@utility draggable {
-  app-region: drag;
-}
-
-@utility draggable-none {
-  app-region: no-drag;
-}

--- a/packages/ui/styles/globals.css
+++ b/packages/ui/styles/globals.css
@@ -129,3 +129,11 @@
     @apply bg-background text-foreground antialiased;
   }
 }
+
+@utility draggable {
+  app-region: drag;
+}
+
+@utility draggable-none {
+  app-region: no-drag;
+}


### PR DESCRIPTION
## Summary

Moves the `@utility draggable` and `@utility draggable-none` Tailwind utilities from `packages/renderer-main/globals.css` to the shared `packages/ui/styles/globals.css`. They're Electron window-chrome primitives (set `app-region: drag` / `no-drag` for hidden-titlebar windows), not specific to the main renderer — any renderer package with a custom titlebar needs them.

Every renderer package already imports the shared UI globals, so relocation is a no-op for existing call sites (`renderer-main`'s `AppTitlebar`, which uses `draggable` / `draggable-none` extensively). Unlocks reuse in follow-up renderer packages without having to redeclare the utilities.

Prep work split off from a GoogleAppWindow branch to keep that review scope focused.

## Test plan

- [x] `bun types:ci` passes across all 8 packages
- [x] Pre-commit hook (oxfmt + oxlint) clean
- [ ] `bun run dev` — main window's titlebar is draggable (try dragging the window by a non-button area of the titlebar); titlebar buttons still clickable (not draggable)
- [ ] Visual: no style regression on the main window's titlebar

https://claude.ai/code/session_01BBFrzPtnKeDjBBij2c4TyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBFrzPtnKeDjBBij2c4TyA)_