### PR TITLE
Route navigation and zoom shortcuts to Google app content view

### DIFF
--- a/packages/app/google-app.ts
+++ b/packages/app/google-app.ts
@@ -11,6 +11,7 @@ import {
   type WebContents,
   WebContentsView,
 } from "electron";
+import { clamp } from "@meru/shared/utils";
 import { accounts } from "./accounts";
 import { config } from "./config";
 import { setupWindowContextMenu } from "./context-menu";
@@ -33,6 +34,9 @@ const GOOGLE_PDF_VIEWER_URL_REGEXP = /googleusercontent\.com\/viewer\/secure\/pd
 const SUPPORTED_GOOGLE_APPS_URL_REGEXP = new RegExp(
   `(${Object.keys(supportedGoogleApps).join("|")})(?:\\.usercontent)?\\.google\\.com`,
 );
+
+const MIN_ZOOM_FACTOR = 0.1;
+const MAX_ZOOM_FACTOR = 3;
 
 function getGoogleAppFromUrl(url: string) {
   return url.match(SUPPORTED_GOOGLE_APPS_URL_REGEXP)?.[1] as SupportedGoogleApp | undefined;
@@ -410,6 +414,10 @@ export class GoogleApp {
 
   setZoomFactor(zoomFactor: number) {
     this.view.webContents.setZoomFactor(zoomFactor);
+  }
+
+  zoomBy(delta: number) {
+    this.setZoomFactor(clamp(this.zoomFactor + delta, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR));
   }
 
   stop() {

--- a/packages/app/google-app.ts
+++ b/packages/app/google-app.ts
@@ -404,6 +404,14 @@ export class GoogleApp {
     this.view.webContents.reloadIgnoringCache();
   }
 
+  get zoomFactor() {
+    return this.view.webContents.getZoomFactor();
+  }
+
+  setZoomFactor(zoomFactor: number) {
+    this.view.webContents.setZoomFactor(zoomFactor);
+  }
+
   stop() {
     this.view.webContents.stop();
   }

--- a/packages/app/google-app.ts
+++ b/packages/app/google-app.ts
@@ -408,16 +408,24 @@ export class GoogleApp {
     this.view.webContents.reloadIgnoringCache();
   }
 
-  get zoomFactor() {
+  zoomIn() {
+    this.setZoomFactor(this.zoomFactor + 0.1);
+  }
+
+  zoomOut() {
+    this.setZoomFactor(this.zoomFactor - 0.1);
+  }
+
+  resetZoom() {
+    this.setZoomFactor(1);
+  }
+
+  private get zoomFactor() {
     return this.view.webContents.getZoomFactor();
   }
 
-  setZoomFactor(zoomFactor: number) {
-    this.view.webContents.setZoomFactor(zoomFactor);
-  }
-
-  zoomBy(delta: number) {
-    this.setZoomFactor(clamp(this.zoomFactor + delta, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR));
+  private setZoomFactor(zoomFactor: number) {
+    this.view.webContents.setZoomFactor(clamp(zoomFactor, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR));
   }
 
   stop() {

--- a/packages/app/google-app.ts
+++ b/packages/app/google-app.ts
@@ -400,6 +400,10 @@ export class GoogleApp {
     this.view.webContents.reload();
   }
 
+  hardReload() {
+    this.view.webContents.reloadIgnoringCache();
+  }
+
   stop() {
     this.view.webContents.stop();
   }

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -408,6 +408,14 @@ export class AppMenu {
             accelerator: "CommandOrControl+R",
             click: () => {
               if (focusedWindow && focusedWindow !== main.window) {
+                const googleApp = GoogleApp.tryFromWebContents(focusedWindow.webContents);
+
+                if (googleApp) {
+                  googleApp.reload();
+
+                  return;
+                }
+
                 focusedWindow.webContents.reload();
 
                 return;
@@ -421,6 +429,14 @@ export class AppMenu {
             accelerator: "CommandOrControl+Shift+R",
             click: async () => {
               if (focusedWindow && focusedWindow !== main.window) {
+                const googleApp = GoogleApp.tryFromWebContents(focusedWindow.webContents);
+
+                if (googleApp) {
+                  googleApp.hardReload();
+
+                  return;
+                }
+
                 focusedWindow.webContents.reloadIgnoringCache();
 
                 return;
@@ -468,6 +484,14 @@ export class AppMenu {
             accelerator: platform.isMacOS ? "Command+[" : "Alt+Left",
             click: () => {
               if (focusedWindow && focusedWindow !== main.window) {
+                const googleApp = GoogleApp.tryFromWebContents(focusedWindow.webContents);
+
+                if (googleApp) {
+                  googleApp.goBack();
+
+                  return;
+                }
+
                 focusedWindow.webContents.navigationHistory.goBack();
 
                 return;
@@ -481,6 +505,14 @@ export class AppMenu {
             accelerator: platform.isMacOS ? "Command+]" : "Alt+Right",
             click: () => {
               if (focusedWindow && focusedWindow !== main.window) {
+                const googleApp = GoogleApp.tryFromWebContents(focusedWindow.webContents);
+
+                if (googleApp) {
+                  googleApp.goForward();
+
+                  return;
+                }
+
                 focusedWindow.webContents.navigationHistory.goForward();
 
                 return;

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -120,6 +120,16 @@ export class AppMenu {
 
     const zoomIn = () => {
       if (focusedWindow && focusedWindow !== main.window) {
+        const googleApp = GoogleApp.tryFromWebContents(focusedWindow.webContents);
+
+        if (googleApp) {
+          googleApp.setZoomFactor(
+            clamp(googleApp.zoomFactor + 0.1, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR),
+          );
+
+          return;
+        }
+
         focusedWindow.webContents.setZoomFactor(
           clamp(focusedWindow.webContents.getZoomFactor() + 0.1, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR),
         );
@@ -138,6 +148,16 @@ export class AppMenu {
 
     const zoomOut = () => {
       if (focusedWindow && focusedWindow !== main.window) {
+        const googleApp = GoogleApp.tryFromWebContents(focusedWindow.webContents);
+
+        if (googleApp) {
+          googleApp.setZoomFactor(
+            clamp(googleApp.zoomFactor - 0.1, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR),
+          );
+
+          return;
+        }
+
         focusedWindow.webContents.setZoomFactor(
           clamp(focusedWindow.webContents.getZoomFactor() - 0.1, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR),
         );
@@ -365,6 +385,14 @@ export class AppMenu {
               const defaultZoomFactor = 1;
 
               if (focusedWindow && focusedWindow !== main.window) {
+                const googleApp = GoogleApp.tryFromWebContents(focusedWindow.webContents);
+
+                if (googleApp) {
+                  googleApp.setZoomFactor(defaultZoomFactor);
+
+                  return;
+                }
+
                 focusedWindow.webContents.setZoomFactor(defaultZoomFactor);
 
                 return;

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -126,13 +126,7 @@ export class AppMenu {
           googleApp.setZoomFactor(
             clamp(googleApp.zoomFactor + 0.1, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR),
           );
-
-          return;
         }
-
-        focusedWindow.webContents.setZoomFactor(
-          clamp(focusedWindow.webContents.getZoomFactor() + 0.1, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR),
-        );
 
         return;
       }
@@ -154,13 +148,7 @@ export class AppMenu {
           googleApp.setZoomFactor(
             clamp(googleApp.zoomFactor - 0.1, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR),
           );
-
-          return;
         }
-
-        focusedWindow.webContents.setZoomFactor(
-          clamp(focusedWindow.webContents.getZoomFactor() - 0.1, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR),
-        );
 
         return;
       }
@@ -385,15 +373,9 @@ export class AppMenu {
               const defaultZoomFactor = 1;
 
               if (focusedWindow && focusedWindow !== main.window) {
-                const googleApp = GoogleApp.tryFromWebContents(focusedWindow.webContents);
-
-                if (googleApp) {
-                  googleApp.setZoomFactor(defaultZoomFactor);
-
-                  return;
-                }
-
-                focusedWindow.webContents.setZoomFactor(defaultZoomFactor);
+                GoogleApp.tryFromWebContents(focusedWindow.webContents)?.setZoomFactor(
+                  defaultZoomFactor,
+                );
 
                 return;
               }
@@ -465,7 +447,13 @@ export class AppMenu {
             accelerator: platform.isMacOS ? "Command+Alt+I" : "Control+Shift+I",
             click: () => {
               if (focusedWindow && focusedWindow !== main.window) {
-                focusedWindow.webContents.openDevTools();
+                const googleApp = GoogleApp.tryFromWebContents(focusedWindow.webContents);
+
+                if (googleApp) {
+                  focusedWindow.webContents.openDevTools({ mode: "detach" });
+
+                  googleApp.view.webContents.openDevTools();
+                }
 
                 return;
               }

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -122,11 +122,9 @@ export class AppMenu {
       if (focusedWindow && focusedWindow !== main.window) {
         const googleApp = GoogleApp.tryFromWebContents(focusedWindow.webContents);
 
-        if (googleApp) {
-          googleApp.setZoomFactor(
-            clamp(googleApp.zoomFactor + 0.1, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR),
-          );
-        }
+        googleApp?.setZoomFactor(
+          clamp(googleApp.zoomFactor + 0.1, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR),
+        );
 
         return;
       }
@@ -144,11 +142,9 @@ export class AppMenu {
       if (focusedWindow && focusedWindow !== main.window) {
         const googleApp = GoogleApp.tryFromWebContents(focusedWindow.webContents);
 
-        if (googleApp) {
-          googleApp.setZoomFactor(
-            clamp(googleApp.zoomFactor - 0.1, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR),
-          );
-        }
+        googleApp?.setZoomFactor(
+          clamp(googleApp.zoomFactor - 0.1, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR),
+        );
 
         return;
       }
@@ -450,7 +446,7 @@ export class AppMenu {
                 const googleApp = GoogleApp.tryFromWebContents(focusedWindow.webContents);
 
                 if (googleApp) {
-                  focusedWindow.webContents.openDevTools({ mode: "detach" });
+                  googleApp.browserWindow.webContents.openDevTools({ mode: "detach" });
 
                   googleApp.view.webContents.openDevTools();
                 }

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -436,15 +436,7 @@ export class AppMenu {
             accelerator: "CommandOrControl+R",
             click: () => {
               if (focusedWindow && focusedWindow !== main.window) {
-                const googleApp = GoogleApp.tryFromWebContents(focusedWindow.webContents);
-
-                if (googleApp) {
-                  googleApp.reload();
-
-                  return;
-                }
-
-                focusedWindow.webContents.reload();
+                GoogleApp.tryFromWebContents(focusedWindow.webContents)?.reload();
 
                 return;
               }
@@ -457,15 +449,7 @@ export class AppMenu {
             accelerator: "CommandOrControl+Shift+R",
             click: async () => {
               if (focusedWindow && focusedWindow !== main.window) {
-                const googleApp = GoogleApp.tryFromWebContents(focusedWindow.webContents);
-
-                if (googleApp) {
-                  googleApp.hardReload();
-
-                  return;
-                }
-
-                focusedWindow.webContents.reloadIgnoringCache();
+                GoogleApp.tryFromWebContents(focusedWindow.webContents)?.hardReload();
 
                 return;
               }
@@ -512,15 +496,7 @@ export class AppMenu {
             accelerator: platform.isMacOS ? "Command+[" : "Alt+Left",
             click: () => {
               if (focusedWindow && focusedWindow !== main.window) {
-                const googleApp = GoogleApp.tryFromWebContents(focusedWindow.webContents);
-
-                if (googleApp) {
-                  googleApp.goBack();
-
-                  return;
-                }
-
-                focusedWindow.webContents.navigationHistory.goBack();
+                GoogleApp.tryFromWebContents(focusedWindow.webContents)?.goBack();
 
                 return;
               }
@@ -533,15 +509,7 @@ export class AppMenu {
             accelerator: platform.isMacOS ? "Command+]" : "Alt+Right",
             click: () => {
               if (focusedWindow && focusedWindow !== main.window) {
-                const googleApp = GoogleApp.tryFromWebContents(focusedWindow.webContents);
-
-                if (googleApp) {
-                  googleApp.goForward();
-
-                  return;
-                }
-
-                focusedWindow.webContents.navigationHistory.goForward();
+                GoogleApp.tryFromWebContents(focusedWindow.webContents)?.goForward();
 
                 return;
               }

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -24,7 +24,6 @@ import { openExternalUrl } from "@/url";
 import { createMeruMessageUrl } from "./protocol";
 import { licenseKey } from "./license-key";
 import { appState } from "./state";
-import { clamp } from "@meru/shared/utils";
 
 export class AppMenu {
   private _menu: Menu | undefined;
@@ -115,16 +114,9 @@ export class AppMenu {
 
     const focusedWindow = BrowserWindow.getFocusedWindow();
 
-    const MIN_ZOOM_FACTOR = 0.1;
-    const MAX_ZOOM_FACTOR = 3;
-
     const zoomIn = () => {
       if (focusedWindow && focusedWindow !== main.window) {
-        const googleApp = GoogleApp.tryFromWebContents(focusedWindow.webContents);
-
-        googleApp?.setZoomFactor(
-          clamp(googleApp.zoomFactor + 0.1, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR),
-        );
+        GoogleApp.tryFromWebContents(focusedWindow.webContents)?.zoomBy(0.1);
 
         return;
       }
@@ -140,11 +132,7 @@ export class AppMenu {
 
     const zoomOut = () => {
       if (focusedWindow && focusedWindow !== main.window) {
-        const googleApp = GoogleApp.tryFromWebContents(focusedWindow.webContents);
-
-        googleApp?.setZoomFactor(
-          clamp(googleApp.zoomFactor - 0.1, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR),
-        );
+        GoogleApp.tryFromWebContents(focusedWindow.webContents)?.zoomBy(-0.1);
 
         return;
       }

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -116,7 +116,7 @@ export class AppMenu {
 
     const zoomIn = () => {
       if (focusedWindow && focusedWindow !== main.window) {
-        GoogleApp.tryFromWebContents(focusedWindow.webContents)?.zoomBy(0.1);
+        GoogleApp.tryFromWebContents(focusedWindow.webContents)?.zoomIn();
 
         return;
       }
@@ -132,7 +132,7 @@ export class AppMenu {
 
     const zoomOut = () => {
       if (focusedWindow && focusedWindow !== main.window) {
-        GoogleApp.tryFromWebContents(focusedWindow.webContents)?.zoomBy(-0.1);
+        GoogleApp.tryFromWebContents(focusedWindow.webContents)?.zoomOut();
 
         return;
       }
@@ -354,15 +354,13 @@ export class AppMenu {
             label: "Reset Zoom",
             accelerator: "CommandOrControl+0",
             click: () => {
-              const defaultZoomFactor = 1;
-
               if (focusedWindow && focusedWindow !== main.window) {
-                GoogleApp.tryFromWebContents(focusedWindow.webContents)?.setZoomFactor(
-                  defaultZoomFactor,
-                );
+                GoogleApp.tryFromWebContents(focusedWindow.webContents)?.resetZoom();
 
                 return;
               }
+
+              const defaultZoomFactor = 1;
 
               for (const [_accountId, instance] of accounts.instances) {
                 instance.gmail.view.webContents.setZoomFactor(defaultZoomFactor);


### PR DESCRIPTION
## Summary

Addresses "Google App toolbar keyboard shortcuts" from `TODO.md`. The menu's `Cmd+R` / `Cmd+Shift+R` / `Cmd+[` / `Cmd+]` / `Cmd+=` / `Cmd+-` / `Cmd+0` branches previously called `focusedWindow.webContents.<method>()` which targets the titlebar renderer, not the `WebContentsView` child holding the Google app content — so on Google app windows these shortcuts silently did nothing (or only affected the toolbar for zoom).

- Routes the menu branches through new parameter-free `GoogleApp` methods — `reload()`, `hardReload()`, `goBack()`, `goForward()`, `zoomIn()`, `zoomOut()`, `resetZoom()` — that operate on the content view.
- `Cmd+Alt+I` (Developer Tools) on a focused Google app window now opens DevTools for both the titlebar (detached) and the content view, matching the main-window pattern.
- Drops the dead-code fallbacks that targeted `focusedWindow.webContents` when no `GoogleApp` was found.
- Zoom clamping (0.1–3) lives inside `GoogleApp.setZoomFactor`, so constants and `clamp` no longer need to live in `menu.ts`.

## Test plan

- [ ] Open a Google app window (e.g. Docs), focus it, verify `Cmd+R` reloads the content (not just the toolbar).
- [ ] `Cmd+Shift+R` does a cache-busting reload of the content.
- [ ] `Cmd+[` / `Cmd+]` navigate history in the content view.
- [ ] `Cmd+=` / `Cmd+-` / `Cmd+0` zoom in / out / reset the content view, clamped between 0.1 and 3.
- [ ] `Cmd+Alt+I` opens two DevTools windows (detached titlebar + attached content view).
- [ ] Main Gmail window shortcuts unaffected.

https://claude.ai/code/session_011hJzhMMAiftduCxhsUjSB8