### PR TITLE
Remove Google Docs debug menu item from dev tools

### DIFF
--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -1,7 +1,6 @@
 import path from "node:path";
 import { is, platform } from "@electron-toolkit/utils";
 import { GITHUB_REPO_URL, WEBSITE_URL } from "@meru/shared/constants";
-import { getGoogleAppUrl } from "@meru/shared/google";
 import {
   app,
   BrowserWindow,
@@ -443,17 +442,6 @@ export class AppMenu {
               main.window.webContents.openDevTools({ mode: "detach" });
 
               selectedAccount.instance.gmail.view.webContents.openDevTools();
-            },
-          },
-          {
-            label: "Open Google Docs in GoogleApp window",
-            visible: is.dev,
-            accelerator: "CommandOrControl+T",
-            click: () => {
-              new GoogleApp({
-                accountId: selectedAccount.config.id,
-                url: getGoogleAppUrl("docs"),
-              });
             },
           },
         ],


### PR DESCRIPTION
## Summary
Removed the "Open Google Docs in GoogleApp window" debug menu item from the development tools menu, along with its associated import.

## Changes
- Removed the debug menu item that opened Google Docs in a GoogleApp window (was only visible in dev mode)
- Removed the unused `getGoogleAppUrl` import from `@meru/shared/google`
- Removed the `GoogleApp` instantiation logic that was triggered by the menu action

## Details
This appears to be cleanup of development/debugging functionality that is no longer needed. The menu item was gated behind `visible: is.dev` and used the keyboard shortcut `CommandOrControl+T`.

https://claude.ai/code/session_01XUo4pKu1nW4sAdKTyRGYx9