### PR TITLE
Remove recently downloaded item notification from titlebar

### DIFF
--- a/packages/app/downloads.ts
+++ b/packages/app/downloads.ts
@@ -6,7 +6,6 @@ import { shell, WebContentsView } from "electron";
 import electronDl from "electron-dl";
 import { config } from "@/config";
 import { createNotification } from "@/notifications";
-import { ipc } from "./ipc";
 import { main } from "./main";
 import { APP_TITLEBAR_HEIGHT, BASE_SPACING } from "@meru/shared/constants";
 import { fileExists } from "./lib/fs";
@@ -65,8 +64,6 @@ class Downloads {
           createdAt: item.getStartTime(),
           exists: true,
         });
-
-        ipc.renderer.send(main.window.webContents, "downloads.itemCompleted");
 
         if (config.get("notifications.downloadCompleted")) {
           createNotification({

--- a/packages/app/downloads.ts
+++ b/packages/app/downloads.ts
@@ -59,14 +59,14 @@ class Downloads {
         const filePath = item.getSavePath();
         const fileName = path.basename(filePath);
 
-        const { id } = this.addDownloadHistoryItem({
+        this.addDownloadHistoryItem({
           fileName,
           filePath,
           createdAt: item.getStartTime(),
           exists: true,
         });
 
-        ipc.renderer.send(main.window.webContents, "downloads.itemCompleted", id);
+        ipc.renderer.send(main.window.webContents, "downloads.itemCompleted");
 
         if (config.get("notifications.downloadCompleted")) {
           createNotification({

--- a/packages/renderer-main/components/app-titlebar.tsx
+++ b/packages/renderer-main/components/app-titlebar.tsx
@@ -32,7 +32,6 @@ import { useConfig } from "@meru/shared/renderer/react-query";
 import {
   useAccountsStore,
   useAppUpdaterStore,
-  useDownloadsStore,
   useFindInPageStore,
   useSettingsStore,
   useTrialStore,
@@ -41,10 +40,6 @@ import { GoogleAppIcon } from "./google-app-icon";
 import { useRoute } from "wouter";
 
 function Download() {
-  const hasUnviewedCompletedDownload = useDownloadsStore(
-    (state) => state.hasUnviewedCompletedDownload,
-  );
-
   return (
     <Button
       variant="ghost"
@@ -52,10 +47,6 @@ function Download() {
       className="draggable-none"
       onClick={() => {
         ipc.main.send("downloads.toggleRecentDownloadHistoryPopup");
-
-        useDownloadsStore.setState({
-          hasUnviewedCompletedDownload: false,
-        });
       }}
       onMouseEnter={() => {
         ipc.main.send("downloads.setDownloadHistoryPopupOnBlurEnabled", false);
@@ -65,11 +56,7 @@ function Download() {
       }}
       title="Download History"
     >
-      <DownloadIcon
-        className={cn({
-          "text-green-600": hasUnviewedCompletedDownload,
-        })}
-      />
+      <DownloadIcon />
     </Button>
   );
 }

--- a/packages/renderer-main/components/app-titlebar.tsx
+++ b/packages/renderer-main/components/app-titlebar.tsx
@@ -1,7 +1,7 @@
 import { ipc } from "@meru/shared/renderer/ipc";
 import { accountColorsMap } from "@meru/shared/accounts";
 import { WEBSITE_URL } from "@meru/shared/constants";
-import { type DownloadItem, googleAppsPinnedApps } from "@meru/shared/types";
+import { googleAppsPinnedApps } from "@meru/shared/types";
 import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
 import { FindInPage as UiFindInPage } from "@meru/ui/components/find-in-page";
@@ -20,14 +20,13 @@ import {
   CircleXIcon,
   DownloadIcon,
   EllipsisVerticalIcon,
-  FileCheckIcon,
   InboxIcon,
   MailSearchIcon,
   MoonIcon,
   SparklesIcon,
 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
-import { navigate, useHashLocation } from "wouter/use-hash-location";
+import { useState } from "react";
+import { navigate } from "wouter/use-hash-location";
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { useConfig } from "@meru/shared/renderer/react-query";
 import {
@@ -41,90 +40,37 @@ import {
 import { GoogleAppIcon } from "./google-app-icon";
 import { useRoute } from "wouter";
 
-function RecentlyDownloadedItem({ item }: { item: DownloadItem }) {
-  const [fadeOut, setFadeOut] = useState(false);
-  const buttonRef = useRef<HTMLButtonElement>(null);
-
-  useEffect(() => {
-    const handleAnimationEnd = () => {
-      if (useDownloadsStore.getState().itemCompleted === item.id) {
-        useDownloadsStore.setState({
-          itemCompleted: null,
-        });
-      }
-    };
-
-    const timer = setTimeout(() => {
-      buttonRef.current?.addEventListener("animationend", handleAnimationEnd);
-
-      setFadeOut(true);
-    }, 10000);
-
-    return () => {
-      clearTimeout(timer);
-
-      buttonRef.current?.removeEventListener("animationend", handleAnimationEnd);
-    };
-  }, [item]);
+function Download() {
+  const hasUnviewedCompletedDownload = useDownloadsStore(
+    (state) => state.hasUnviewedCompletedDownload,
+  );
 
   return (
     <Button
-      ref={buttonRef}
       variant="ghost"
-      size="sm"
-      className={cn("max-w-56 animate-in fade-in", {
-        "animate-out fade-out": fadeOut,
-      })}
+      size="icon-sm"
+      className="draggable-none"
       onClick={() => {
-        ipc.main.send("downloads.openFile", item);
+        ipc.main.send("downloads.toggleRecentDownloadHistoryPopup");
 
         useDownloadsStore.setState({
-          itemCompleted: null,
+          hasUnviewedCompletedDownload: false,
         });
       }}
+      onMouseEnter={() => {
+        ipc.main.send("downloads.setDownloadHistoryPopupOnBlurEnabled", false);
+      }}
+      onMouseLeave={() => {
+        ipc.main.send("downloads.setDownloadHistoryPopupOnBlurEnabled", true);
+      }}
+      title="Download History"
     >
-      <FileCheckIcon />
-      <div className="truncate">{item.fileName}</div>
+      <DownloadIcon
+        className={cn({
+          "text-green-600": hasUnviewedCompletedDownload,
+        })}
+      />
     </Button>
-  );
-}
-
-function Download() {
-  const [_location] = useHashLocation();
-
-  const { config } = useConfig();
-
-  if (!config) {
-    return;
-  }
-
-  const completedDownloadItem = useDownloadsStore(
-    (state) =>
-      (state.itemCompleted &&
-        config?.["downloads.history"].find((item) => item.id === state.itemCompleted)) ||
-      null,
-  );
-
-  return (
-    <div className="draggable-none flex items-center gap-1">
-      {completedDownloadItem && <RecentlyDownloadedItem item={completedDownloadItem} />}
-      <Button
-        variant="ghost"
-        size="icon-sm"
-        onClick={() => {
-          ipc.main.send("downloads.toggleRecentDownloadHistoryPopup");
-        }}
-        onMouseEnter={() => {
-          ipc.main.send("downloads.setDownloadHistoryPopupOnBlurEnabled", false);
-        }}
-        onMouseLeave={() => {
-          ipc.main.send("downloads.setDownloadHistoryPopupOnBlurEnabled", true);
-        }}
-        title="Download History"
-      >
-        <DownloadIcon />
-      </Button>
-    </div>
   );
 }
 

--- a/packages/renderer-main/lib/stores.ts
+++ b/packages/renderer-main/lib/stores.ts
@@ -99,18 +99,6 @@ ipc.renderer.on("trial.daysLeftChanged", (_event, daysLeft) => {
   useTrialStore.setState({ daysLeft });
 });
 
-export const useDownloadsStore = create<{
-  hasUnviewedCompletedDownload: boolean;
-}>(() => ({
-  hasUnviewedCompletedDownload: false,
-}));
-
-ipc.renderer.on("downloads.itemCompleted", () => {
-  useDownloadsStore.setState({
-    hasUnviewedCompletedDownload: true,
-  });
-});
-
 export const useAppUpdaterStore = create<{
   version: string | null;
   dismiss: () => void;

--- a/packages/renderer-main/lib/stores.ts
+++ b/packages/renderer-main/lib/stores.ts
@@ -100,15 +100,15 @@ ipc.renderer.on("trial.daysLeftChanged", (_event, daysLeft) => {
 });
 
 export const useDownloadsStore = create<{
-  itemCompleted: string | null;
+  hasUnviewedCompletedDownload: boolean;
 }>(() => ({
-  itemCompleted: null,
+  hasUnviewedCompletedDownload: false,
 }));
 
-ipc.renderer.on("downloads.itemCompleted", (_event, itemId) => {
-  useDownloadsStore.setState(() => ({
-    itemCompleted: itemId,
-  }));
+ipc.renderer.on("downloads.itemCompleted", () => {
+  useDownloadsStore.setState({
+    hasUnviewedCompletedDownload: true,
+  });
 });
 
 export const useAppUpdaterStore = create<{

--- a/packages/renderer-main/routes/download-history.tsx
+++ b/packages/renderer-main/routes/download-history.tsx
@@ -1,6 +1,4 @@
-import { useEffect } from "react";
 import { SettingsHeader, SettingsTitle } from "@/components/settings";
-import { useDownloadsStore } from "@/lib/stores";
 import { useConfig, useConfigMutation } from "@meru/shared/renderer/react-query";
 import { Button } from "@meru/ui/components/button";
 import {
@@ -137,12 +135,6 @@ function DownloadHistoryContent() {
 }
 
 export function DownloadHistory() {
-  useEffect(() => {
-    useDownloadsStore.setState({
-      hasUnviewedCompletedDownload: false,
-    });
-  }, []);
-
   return (
     <>
       <SettingsHeader>

--- a/packages/renderer-main/routes/download-history.tsx
+++ b/packages/renderer-main/routes/download-history.tsx
@@ -139,7 +139,7 @@ function DownloadHistoryContent() {
 export function DownloadHistory() {
   useEffect(() => {
     useDownloadsStore.setState({
-      itemCompleted: null,
+      hasUnviewedCompletedDownload: false,
     });
   }, []);
 

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -242,7 +242,7 @@ export type IpcMainEvents =
 
 export type IpcRendererEvent = {
   navigate: [to: string];
-  "downloads.itemCompleted": [itemId: string];
+  "downloads.itemCompleted": [];
   "settings.setIsOpen": [isOpen: boolean];
   "gmail.navigateTo": [hashLocation: GmailHashLocation];
   "gmail.handleMessage": [messageId: string, action: keyof typeof GMAIL_ACTION_CODE_MAP];

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -242,7 +242,6 @@ export type IpcMainEvents =
 
 export type IpcRendererEvent = {
   navigate: [to: string];
-  "downloads.itemCompleted": [];
   "settings.setIsOpen": [isOpen: boolean];
   "gmail.navigateTo": [hashLocation: GmailHashLocation];
   "gmail.handleMessage": [messageId: string, action: keyof typeof GMAIL_ACTION_CODE_MAP];


### PR DESCRIPTION
## Summary
This PR removes the recently downloaded item notification feature from the app titlebar. The notification that appeared when a download completed has been removed, simplifying the download UI to only show the download history button.

## Key Changes
- **Removed `RecentlyDownloadedItem` component** from `app-titlebar.tsx` that displayed completed downloads with fade-out animation
- **Simplified `Download` component** to only render the download history button without the recently downloaded item notification
- **Removed `useDownloadsStore`** from stores that tracked the `itemCompleted` state
- **Removed IPC event handler** `downloads.itemCompleted` that notified the renderer when downloads completed
- **Removed IPC event emission** in `downloads.ts` that sent the `downloads.itemCompleted` event to the renderer
- **Removed IPC event type** `downloads.itemCompleted` from shared types
- **Cleaned up unused imports** including `DownloadItem` type, `FileCheckIcon`, `useEffect`, `useRef`, and `useHashLocation`
- **Removed cleanup logic** in `download-history.tsx` that reset the `itemCompleted` state

## Implementation Details
The download history button remains functional and accessible via the titlebar, but no longer shows a transient notification when downloads complete. Users can still access their download history through the download history popup.

https://claude.ai/code/session_01TC19fHod7jDyRwMouvBTeT