### PR TITLE
Reveal downloaded file in file manager on notification click

### DIFF
--- a/packages/app/downloads.ts
+++ b/packages/app/downloads.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
+import { platform } from "@electron-toolkit/utils";
 import { ms } from "@meru/shared/ms";
 import type { DownloadItem } from "@meru/shared/types";
 import { shell, WebContentsView } from "electron";
@@ -10,6 +11,12 @@ import { main } from "./main";
 import { APP_TITLEBAR_HEIGHT, BASE_SPACING } from "@meru/shared/constants";
 import { fileExists } from "./lib/fs";
 import { getPreloadPath, loadRenderer } from "./lib/window";
+
+const FILE_MANAGER_NAME = platform.isMacOS
+  ? "Finder"
+  : platform.isWindows
+    ? "File Explorer"
+    : "your file manager";
 
 class Downloads {
   recentDownloadHistoryPopup: WebContentsView | null = null;
@@ -67,8 +74,8 @@ class Downloads {
 
         if (config.get("notifications.downloadCompleted")) {
           createNotification({
-            title: `Download ${state}`,
-            body: fileName,
+            title: `Download ${state}: ${fileName}`,
+            body: `Click to show the file in ${FILE_MANAGER_NAME}`,
             click: () => {
               shell.showItemInFolder(filePath);
             },

--- a/packages/app/downloads.ts
+++ b/packages/app/downloads.ts
@@ -70,7 +70,7 @@ class Downloads {
             title: `Download ${state}`,
             body: fileName,
             click: () => {
-              shell.openPath(filePath);
+              shell.showItemInFolder(filePath);
             },
           });
         }


### PR DESCRIPTION
## Summary
- Clicking a download-completed notification now reveals the file in the system file manager (`shell.showItemInFolder`) instead of opening it directly (`shell.openPath`).
- Notification title now includes the file name: `Download <state>: <fileName>`.
- Notification body prompts the action with a platform-appropriate file-manager name:
  - macOS: `Click to show the file in Finder`
  - Windows: `Click to show the file in File Explorer`
  - Linux: `Click to show the file in your file manager`

## Test plan
- [ ] Trigger a download and confirm the notification title reads `Download completed: <fileName>` and the body matches the host OS.
- [ ] Click the notification on macOS — Finder opens with the file highlighted.
- [ ] Click the notification on Windows — File Explorer opens with the file highlighted.
- [ ] Click the notification on Linux — the system file manager opens at the file's location.

https://claude.ai/code/session_01SQ1nf2moqqc7yfG6NcdLfH