### PR TITLE
hide account badge in google app window when only one account

### DIFF
--- a/packages/app/google-app.ts
+++ b/packages/app/google-app.ts
@@ -260,9 +260,14 @@ export class GoogleApp {
       ...options,
     });
 
+    const searchParams = new URLSearchParams();
+
+    searchParams.set("accountId", this.accountId);
+
     loadRenderer(browserWindow, {
       renderer: "google-app",
       port: 3002,
+      searchParams,
     });
 
     return browserWindow;

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -185,6 +185,10 @@ class Ipc {
     });
 
     ipc.main.handle("googleApp.getAccount", (event) => {
+      if (accounts.getAccountConfigs().length === 1) {
+        return null;
+      }
+
       return GoogleApp.fromWebContents(event.sender).account.config;
     });
 

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -185,10 +185,6 @@ class Ipc {
     });
 
     ipc.main.handle("googleApp.getAccount", (event) => {
-      if (accounts.getAccountConfigs().length === 1) {
-        return null;
-      }
-
       return GoogleApp.fromWebContents(event.sender).account.config;
     });
 

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -184,10 +184,6 @@ class Ipc {
       selectedAccount.instance.gmail.search(searchQuery);
     });
 
-    ipc.main.handle("googleApp.getAccount", (event) => {
-      return GoogleApp.fromWebContents(event.sender).account.config;
-    });
-
     ipc.main.handle("googleApp.getLoadingState", (event) => {
       return GoogleApp.fromWebContents(event.sender).isLoading;
     });

--- a/packages/renderer-google-app/index.tsx
+++ b/packages/renderer-google-app/index.tsx
@@ -11,7 +11,8 @@ import {
   TitlebarPageTitle,
   TitlebarRight,
 } from "@meru/ui/components/titlebar";
-import { useQuery } from "@tanstack/react-query";
+import { useConfig } from "@meru/shared/renderer/react-query";
+import { skipToken, useQuery } from "@tanstack/react-query";
 import {
   ArrowLeftIcon,
   ArrowRightIcon,
@@ -100,9 +101,14 @@ function App() {
     totalMatches: 0,
   });
 
+  const { config } = useConfig();
+
   const { data: account } = useQuery({
     queryKey: ["googleApp.account"],
-    queryFn: () => ipc.main.invoke("googleApp.getAccount"),
+    queryFn:
+      config && config.accounts.length > 1
+        ? () => ipc.main.invoke("googleApp.getAccount")
+        : skipToken,
     staleTime: Number.POSITIVE_INFINITY,
   });
 

--- a/packages/renderer-google-app/index.tsx
+++ b/packages/renderer-google-app/index.tsx
@@ -12,7 +12,6 @@ import {
   TitlebarRight,
 } from "@meru/ui/components/titlebar";
 import { useConfig } from "@meru/shared/renderer/react-query";
-import { skipToken, useQuery } from "@tanstack/react-query";
 import {
   ArrowLeftIcon,
   ArrowRightIcon,
@@ -24,6 +23,7 @@ import {
   XIcon,
 } from "lucide-react";
 import { useEffect, useState } from "react";
+import { useSearchParams } from "wouter";
 
 function ReloadButton() {
   const [loading, setLoading] = useState(false);
@@ -103,14 +103,11 @@ function App() {
 
   const { config } = useConfig();
 
-  const { data: account } = useQuery({
-    queryKey: ["googleApp.account"],
-    queryFn:
-      config && config.accounts.length > 1
-        ? () => ipc.main.invoke("googleApp.getAccount")
-        : skipToken,
-    staleTime: Number.POSITIVE_INFINITY,
-  });
+  const [searchParams] = useSearchParams();
+
+  const account = config?.accounts.find(
+    (accountConfig) => accountConfig.id === searchParams.get("accountId"),
+  );
 
   useEffect(() => {
     return ipc.renderer.on("googleApp.navigationStateChanged", (_event, state) => {
@@ -160,7 +157,9 @@ function App() {
           </TitlebarIconButton>
           <ReloadButton />
         </TitlebarButtonGroup>
-        {account && <AccountBadge label={account.label} color={account.color} />}
+        {config && config.accounts.length > 1 && account && (
+          <AccountBadge label={account.label} color={account.color} />
+        )}
         <TitlebarPageTitle>{pageTitle}</TitlebarPageTitle>
       </TitlebarLeft>
       <TitlebarRight>

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -236,7 +236,7 @@ export type IpcMainEvents =
       "app.setLoginItemSettings": (settings: Partial<LoginItemSettings>) => void;
       "app.getIsDefaultMailtoClient": () => boolean;
       "app.setAsDefaultMailtoClient": () => void;
-      "googleApp.getAccount": () => AccountConfig | null;
+      "googleApp.getAccount": () => AccountConfig;
       "googleApp.getLoadingState": () => boolean;
     };
 

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -236,7 +236,6 @@ export type IpcMainEvents =
       "app.setLoginItemSettings": (settings: Partial<LoginItemSettings>) => void;
       "app.getIsDefaultMailtoClient": () => boolean;
       "app.setAsDefaultMailtoClient": () => void;
-      "googleApp.getAccount": () => AccountConfig;
       "googleApp.getLoadingState": () => boolean;
     };
 

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -236,7 +236,7 @@ export type IpcMainEvents =
       "app.setLoginItemSettings": (settings: Partial<LoginItemSettings>) => void;
       "app.getIsDefaultMailtoClient": () => boolean;
       "app.setAsDefaultMailtoClient": () => void;
-      "googleApp.getAccount": () => AccountConfig;
+      "googleApp.getAccount": () => AccountConfig | null;
       "googleApp.getLoadingState": () => boolean;
     };
 


### PR DESCRIPTION
## Summary
- Hide the `AccountBadge` in the Google App titlebar when only one account is configured.
- Pass the owning `accountId` as a URL search param when loading the Google App renderer, and look the account up via `useConfig` on the renderer side.
- Remove the now-unused `googleApp.getAccount` IPC handler and its type.

## Changes
- `packages/app/google-app.ts` — set `accountId` on the renderer's search params in `createBrowserWindow`.
- `packages/renderer-google-app/index.tsx` — read `accountId` with `useSearchParams` from `wouter`, find the account in `config.accounts`, and render the badge only when `config.accounts.length > 1`.
- `packages/app/ipc.ts` / `packages/shared/types.ts` — drop the `googleApp.getAccount` IPC.

## Test plan
- [ ] With a single account configured, open a Google App window — no account badge shown in the titlebar.
- [ ] With 2+ accounts configured, open a Google App window — badge shows the correct label and color for the owning account.
- [ ] Verify no TypeScript errors (`bun types:ci`).

https://claude.ai/code/session_016BG78TYNmhifvxirqH41WA