### PR TITLE
Refactor download history popup to support multiple windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,8 @@ This installs dependencies and runs postinstall scripts (including the lefthook 
   - `startMinutes`/`endMinutes` not `s`/`e`
   - `aStart`/`aEnd`/`bStart`/`bEnd` not `aS`/`aE`/`bS`/`bE`
   - `event` not `e`, `error` not `err`, `index` not `i` (unless in a for loop counter)
-- Avoid generic/contextless names even when they're full words — pick a name that carries the domain. `raw`, `data`, `parsed`, `record`, `result`, `value`, `item`, `obj`, `tmp` are all red flags on their own. Prefer `gtkDecorationLayout` over `layout`, `savedLanguages` over `languages`, `accountConfigs` over `configs`. This lets a reader understand a line without tracing back to where the value came from.
+- Avoid generic/contextless names even when they're full words — pick a name that carries the domain. `raw`, `data`, `parsed`, `record`, `result`, `value`, `item`, `obj`, `tmp` are all red flags on their own. Prefer `gtkDecorationLayout` over `layout`, `savedLanguages` over `languages`, `accountConfigs` over `configs`, `parentWindowBounds` over `parentBounds`. This lets a reader understand a line without tracing back to where the value came from.
+- Applies equally to instance fields — `recentDownloadHistoryParentWindow` beats `popupParentWindow` because the field participates in the same "is the popup open?" check as `recentDownloadHistoryView`, and matching the domain prefix makes the pairing obvious.
 
 ## Code Formatting
 

--- a/packages/app/downloads.ts
+++ b/packages/app/downloads.ts
@@ -18,9 +18,9 @@ const FILE_MANAGER_NAME = platform.isMacOS
     : "your file manager";
 
 class Downloads {
-  recentDownloadHistoryPopup: WebContentsView | null = null;
+  recentDownloadHistoryView: WebContentsView | null = null;
 
-  popupParentWindow: BrowserWindow | null = null;
+  recentDownloadHistoryParentWindow: BrowserWindow | null = null;
 
   downloadHistoryPopupOnBlurEnabled = false;
 
@@ -111,17 +111,17 @@ class Downloads {
   }
 
   setRecentDownloadHistoryPopupBounds = () => {
-    if (!this.recentDownloadHistoryPopup || !this.popupParentWindow) {
+    if (!this.recentDownloadHistoryView || !this.recentDownloadHistoryParentWindow) {
       return;
     }
 
     const width = BASE_SPACING * 48;
 
     const parentBounds = platform.isWindows
-      ? this.popupParentWindow.getContentBounds()
-      : this.popupParentWindow.getBounds();
+      ? this.recentDownloadHistoryParentWindow.getContentBounds()
+      : this.recentDownloadHistoryParentWindow.getBounds();
 
-    this.recentDownloadHistoryPopup.setBounds({
+    this.recentDownloadHistoryView.setBounds({
       x: parentBounds.width - width - BASE_SPACING,
       y: APP_TITLEBAR_HEIGHT + BASE_SPACING,
       width,
@@ -130,23 +130,28 @@ class Downloads {
   };
 
   closeRecentDownloadHistoryPopup = () => {
-    if (this.recentDownloadHistoryPopup && this.popupParentWindow) {
-      this.recentDownloadHistoryPopup.webContents.removeAllListeners();
+    if (this.recentDownloadHistoryView && this.recentDownloadHistoryParentWindow) {
+      this.recentDownloadHistoryView.webContents.removeAllListeners();
 
-      this.recentDownloadHistoryPopup.webContents.close();
+      this.recentDownloadHistoryView.webContents.close();
 
-      this.popupParentWindow.contentView.removeChildView(this.recentDownloadHistoryPopup);
+      this.recentDownloadHistoryParentWindow.contentView.removeChildView(
+        this.recentDownloadHistoryView,
+      );
 
-      this.popupParentWindow.removeListener("resize", this.setRecentDownloadHistoryPopupBounds);
+      this.recentDownloadHistoryParentWindow.removeListener(
+        "resize",
+        this.setRecentDownloadHistoryPopupBounds,
+      );
 
-      this.recentDownloadHistoryPopup = null;
-      this.popupParentWindow = null;
+      this.recentDownloadHistoryView = null;
+      this.recentDownloadHistoryParentWindow = null;
     }
   };
 
   toggleRecentDownloadHistoryPopup(parentWindow: BrowserWindow) {
-    if (this.recentDownloadHistoryPopup) {
-      const wasSameWindow = this.popupParentWindow === parentWindow;
+    if (this.recentDownloadHistoryView) {
+      const wasSameWindow = this.recentDownloadHistoryParentWindow === parentWindow;
 
       this.closeRecentDownloadHistoryPopup();
 
@@ -155,25 +160,25 @@ class Downloads {
       }
     }
 
-    this.recentDownloadHistoryPopup = new WebContentsView({
+    this.recentDownloadHistoryView = new WebContentsView({
       webPreferences: {
         preload: getPreloadPath("renderer"),
       },
     });
 
-    this.popupParentWindow = parentWindow;
+    this.recentDownloadHistoryParentWindow = parentWindow;
 
-    loadRenderer(this.recentDownloadHistoryPopup, {
+    loadRenderer(this.recentDownloadHistoryView, {
       renderer: "popup",
       port: 3001,
       hash: "recent-download-history",
     });
 
-    parentWindow.contentView.addChildView(this.recentDownloadHistoryPopup);
+    parentWindow.contentView.addChildView(this.recentDownloadHistoryView);
 
     this.setRecentDownloadHistoryPopupBounds();
 
-    this.recentDownloadHistoryPopup.webContents.once("blur", () => {
+    this.recentDownloadHistoryView.webContents.once("blur", () => {
       if (this.downloadHistoryPopupOnBlurEnabled) {
         this.closeRecentDownloadHistoryPopup();
       }
@@ -181,7 +186,7 @@ class Downloads {
 
     parentWindow.on("resize", this.setRecentDownloadHistoryPopupBounds);
 
-    this.recentDownloadHistoryPopup.setBorderRadius(BASE_SPACING * 2);
+    this.recentDownloadHistoryView.setBorderRadius(BASE_SPACING * 2);
 
     return true;
   }

--- a/packages/app/downloads.ts
+++ b/packages/app/downloads.ts
@@ -117,12 +117,12 @@ class Downloads {
 
     const width = BASE_SPACING * 48;
 
-    const parentBounds = platform.isWindows
+    const parentWindowBounds = platform.isWindows
       ? this.recentDownloadHistoryParentWindow.getContentBounds()
       : this.recentDownloadHistoryParentWindow.getBounds();
 
     this.recentDownloadHistoryView.setBounds({
-      x: parentBounds.width - width - BASE_SPACING,
+      x: parentWindowBounds.width - width - BASE_SPACING,
       y: APP_TITLEBAR_HEIGHT + BASE_SPACING,
       width,
       height: BASE_SPACING * 44,

--- a/packages/app/downloads.ts
+++ b/packages/app/downloads.ts
@@ -3,11 +3,10 @@ import path from "node:path";
 import { platform } from "@electron-toolkit/utils";
 import { ms } from "@meru/shared/ms";
 import type { DownloadItem } from "@meru/shared/types";
-import { shell, WebContentsView } from "electron";
+import { BrowserWindow, shell, WebContentsView } from "electron";
 import electronDl from "electron-dl";
 import { config } from "@/config";
 import { createNotification } from "@/notifications";
-import { main } from "./main";
 import { APP_TITLEBAR_HEIGHT, BASE_SPACING } from "@meru/shared/constants";
 import { fileExists } from "./lib/fs";
 import { getPreloadPath, loadRenderer } from "./lib/window";
@@ -20,6 +19,8 @@ const FILE_MANAGER_NAME = platform.isMacOS
 
 class Downloads {
   recentDownloadHistoryPopup: WebContentsView | null = null;
+
+  popupParentWindow: BrowserWindow | null = null;
 
   downloadHistoryPopupOnBlurEnabled = false;
 
@@ -110,14 +111,18 @@ class Downloads {
   }
 
   setRecentDownloadHistoryPopupBounds = () => {
-    if (!this.recentDownloadHistoryPopup) {
+    if (!this.recentDownloadHistoryPopup || !this.popupParentWindow) {
       return;
     }
 
     const width = BASE_SPACING * 48;
 
+    const parentBounds = platform.isWindows
+      ? this.popupParentWindow.getContentBounds()
+      : this.popupParentWindow.getBounds();
+
     this.recentDownloadHistoryPopup.setBounds({
-      x: main.getWindowBounds().width - width - BASE_SPACING,
+      x: parentBounds.width - width - BASE_SPACING,
       y: APP_TITLEBAR_HEIGHT + BASE_SPACING,
       width,
       height: BASE_SPACING * 44,
@@ -125,24 +130,29 @@ class Downloads {
   };
 
   closeRecentDownloadHistoryPopup = () => {
-    if (this.recentDownloadHistoryPopup) {
+    if (this.recentDownloadHistoryPopup && this.popupParentWindow) {
       this.recentDownloadHistoryPopup.webContents.removeAllListeners();
 
       this.recentDownloadHistoryPopup.webContents.close();
 
-      main.window.contentView.removeChildView(this.recentDownloadHistoryPopup);
+      this.popupParentWindow.contentView.removeChildView(this.recentDownloadHistoryPopup);
 
-      main.window.removeListener("resize", this.setRecentDownloadHistoryPopupBounds);
+      this.popupParentWindow.removeListener("resize", this.setRecentDownloadHistoryPopupBounds);
 
       this.recentDownloadHistoryPopup = null;
+      this.popupParentWindow = null;
     }
   };
 
-  toggleRecentDownloadHistoryPopup() {
+  toggleRecentDownloadHistoryPopup(parentWindow: BrowserWindow) {
     if (this.recentDownloadHistoryPopup) {
+      const wasSameWindow = this.popupParentWindow === parentWindow;
+
       this.closeRecentDownloadHistoryPopup();
 
-      return false;
+      if (wasSameWindow) {
+        return false;
+      }
     }
 
     this.recentDownloadHistoryPopup = new WebContentsView({
@@ -151,13 +161,15 @@ class Downloads {
       },
     });
 
+    this.popupParentWindow = parentWindow;
+
     loadRenderer(this.recentDownloadHistoryPopup, {
       renderer: "popup",
       port: 3001,
       hash: "recent-download-history",
     });
 
-    main.window.contentView.addChildView(this.recentDownloadHistoryPopup);
+    parentWindow.contentView.addChildView(this.recentDownloadHistoryPopup);
 
     this.setRecentDownloadHistoryPopupBounds();
 
@@ -167,7 +179,7 @@ class Downloads {
       }
     });
 
-    main.window.on("resize", this.setRecentDownloadHistoryPopupBounds);
+    parentWindow.on("resize", this.setRecentDownloadHistoryPopupBounds);
 
     this.recentDownloadHistoryPopup.setBorderRadius(BASE_SPACING * 2);
 

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -417,8 +417,14 @@ class Ipc {
       });
     });
 
-    ipc.main.on("downloads.toggleRecentDownloadHistoryPopup", () => {
-      if (downloads.toggleRecentDownloadHistoryPopup()) {
+    ipc.main.on("downloads.toggleRecentDownloadHistoryPopup", (event) => {
+      const parentWindow = BrowserWindow.fromWebContents(event.sender);
+
+      if (!parentWindow) {
+        return;
+      }
+
+      if (downloads.toggleRecentDownloadHistoryPopup(parentWindow)) {
         downloads.checkDownloadHistoryItems(MAX_RECENT_DOWNLOAD_HISTORY_ITEMS);
       }
     });

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -47,9 +47,9 @@ class Ipc {
     config.onDidAnyChange(() => {
       ipc.renderer.send(main.window.webContents, "config.configChanged", config.store);
 
-      if (downloads.recentDownloadHistoryPopup) {
+      if (downloads.recentDownloadHistoryView) {
         ipc.renderer.send(
-          downloads.recentDownloadHistoryPopup.webContents,
+          downloads.recentDownloadHistoryView.webContents,
           "config.configChanged",
           config.store,
         );

--- a/packages/renderer-google-app/index.tsx
+++ b/packages/renderer-google-app/index.tsx
@@ -26,7 +26,7 @@ import {
 } from "lucide-react";
 import { useEffect, useState } from "react";
 
-function Download() {
+function RecentDownloadHistoryButton() {
   return (
     <Button
       variant="ghost"
@@ -41,7 +41,7 @@ function Download() {
       onMouseLeave={() => {
         ipc.main.send("downloads.setDownloadHistoryPopupOnBlurEnabled", true);
       }}
-      title="Download History"
+      title="Recent Download History"
     >
       <DownloadIcon />
     </Button>
@@ -195,7 +195,7 @@ function App() {
             setFindInPageState((state) => ({ ...state, isActive: false }));
           }}
         />
-        <Download />
+        <RecentDownloadHistoryButton />
         <TitlebarButtonGroup>
           <CopyUrlButton />
           <TitlebarIconButton

--- a/packages/renderer-google-app/index.tsx
+++ b/packages/renderer-google-app/index.tsx
@@ -2,7 +2,6 @@ import { ipc } from "@meru/shared/renderer/ipc";
 import { ms } from "@meru/shared/ms";
 import { renderApp } from "@meru/shared/renderer/react";
 import { AccountBadge } from "@meru/ui/components/account-badge";
-import { Button } from "@meru/ui/components/button";
 import { FindInPage } from "@meru/ui/components/find-in-page";
 import {
   Titlebar,
@@ -28,10 +27,7 @@ import { useEffect, useState } from "react";
 
 function RecentDownloadHistoryButton() {
   return (
-    <Button
-      variant="ghost"
-      size="icon-sm"
-      className="draggable-none"
+    <TitlebarIconButton
       onClick={() => {
         ipc.main.send("downloads.toggleRecentDownloadHistoryPopup");
       }}
@@ -44,7 +40,7 @@ function RecentDownloadHistoryButton() {
       title="Recent Download History"
     >
       <DownloadIcon />
-    </Button>
+    </TitlebarIconButton>
   );
 }
 
@@ -195,8 +191,8 @@ function App() {
             setFindInPageState((state) => ({ ...state, isActive: false }));
           }}
         />
-        <RecentDownloadHistoryButton />
         <TitlebarButtonGroup>
+          <RecentDownloadHistoryButton />
           <CopyUrlButton />
           <TitlebarIconButton
             title="Open in Browser"

--- a/packages/renderer-google-app/index.tsx
+++ b/packages/renderer-google-app/index.tsx
@@ -2,6 +2,7 @@ import { ipc } from "@meru/shared/renderer/ipc";
 import { ms } from "@meru/shared/ms";
 import { renderApp } from "@meru/shared/renderer/react";
 import { AccountBadge } from "@meru/ui/components/account-badge";
+import { Button } from "@meru/ui/components/button";
 import { FindInPage } from "@meru/ui/components/find-in-page";
 import {
   Titlebar,
@@ -17,12 +18,35 @@ import {
   ArrowRightIcon,
   CheckIcon,
   CopyIcon,
+  DownloadIcon,
   ExternalLinkIcon,
   LoaderCircleIcon,
   RotateCwIcon,
   XIcon,
 } from "lucide-react";
 import { useEffect, useState } from "react";
+
+function Download() {
+  return (
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      className="draggable-none"
+      onClick={() => {
+        ipc.main.send("downloads.toggleRecentDownloadHistoryPopup");
+      }}
+      onMouseEnter={() => {
+        ipc.main.send("downloads.setDownloadHistoryPopupOnBlurEnabled", false);
+      }}
+      onMouseLeave={() => {
+        ipc.main.send("downloads.setDownloadHistoryPopupOnBlurEnabled", true);
+      }}
+      title="Download History"
+    >
+      <DownloadIcon />
+    </Button>
+  );
+}
 
 function ReloadButton() {
   const [loading, setLoading] = useState(false);
@@ -171,6 +195,7 @@ function App() {
             setFindInPageState((state) => ({ ...state, isActive: false }));
           }}
         />
+        <Download />
         <TitlebarButtonGroup>
           <CopyUrlButton />
           <TitlebarIconButton

--- a/packages/renderer-main/components/app-titlebar.tsx
+++ b/packages/renderer-main/components/app-titlebar.tsx
@@ -375,10 +375,8 @@ export function AppTitlebar() {
             <Trial />
             <FindInPage />
             <PinnedGoogleApps />
-            <TitlebarButtonGroup>
-              <RecentDownloadHistoryButton />
-              <DoNotDisturb />
-            </TitlebarButtonGroup>
+            <RecentDownloadHistoryButton />
+            <DoNotDisturb />
           </div>
           {appUpdateVersion && (
             <Button

--- a/packages/renderer-main/components/app-titlebar.tsx
+++ b/packages/renderer-main/components/app-titlebar.tsx
@@ -39,12 +39,9 @@ import {
 import { GoogleAppIcon } from "./google-app-icon";
 import { useRoute } from "wouter";
 
-function Download() {
+function RecentDownloadHistoryButton() {
   return (
-    <Button
-      variant="ghost"
-      size="icon-sm"
-      className="draggable-none"
+    <TitlebarIconButton
       onClick={() => {
         ipc.main.send("downloads.toggleRecentDownloadHistoryPopup");
       }}
@@ -54,10 +51,10 @@ function Download() {
       onMouseLeave={() => {
         ipc.main.send("downloads.setDownloadHistoryPopupOnBlurEnabled", true);
       }}
-      title="Download History"
+      title="Recent Download History"
     >
       <DownloadIcon />
-    </Button>
+    </TitlebarIconButton>
   );
 }
 
@@ -378,8 +375,10 @@ export function AppTitlebar() {
             <Trial />
             <FindInPage />
             <PinnedGoogleApps />
-            <Download />
-            <DoNotDisturb />
+            <TitlebarButtonGroup>
+              <RecentDownloadHistoryButton />
+              <DoNotDisturb />
+            </TitlebarButtonGroup>
           </div>
           {appUpdateVersion && (
             <Button


### PR DESCRIPTION
## Summary
Refactored the download history popup system to be window-agnostic, allowing the popup to be opened from any window rather than being tied to the main window. This enables better support for multi-window scenarios and improves code maintainability.

## Key Changes
- **Removed main window dependency**: Eliminated the import of `main` from downloads.ts and replaced hardcoded references to `main.window` with a `parentWindow` parameter passed at runtime
- **Added parent window tracking**: Introduced `recentDownloadHistoryParentWindow` field to track which window owns the current popup, enabling proper cleanup and bounds calculations
- **Renamed for clarity**: Changed `recentDownloadHistoryPopup` to `recentDownloadHistoryView` to better reflect that it's a view, not a window
- **Updated toggle logic**: Modified `toggleRecentDownloadHistoryPopup()` to accept a `BrowserWindow` parameter and intelligently handle toggling (closes if same window, opens in new window if different)
- **Fixed IPC integration**: Updated the IPC handler to extract the parent window from the event sender, ensuring the popup opens in the correct window context
- **Unified button styling**: Refactored both main and Google app titlebar download buttons to use consistent `TitlebarIconButton` component and naming (`RecentDownloadHistoryButton`)
- **Updated documentation**: Added example to CLAUDE.md coding guidelines showing `parentWindowBounds` as a better alternative to generic names

## Implementation Details
- The popup now calculates bounds relative to the parent window's dimensions, with platform-specific handling for Windows (using `getContentBounds()`) vs other platforms (using `getBounds()`)
- Popup state is properly cleaned up when switching between windows or closing
- All event listeners are attached to the correct parent window instance

https://claude.ai/code/session_01FCKbXY2185E7Jk4QxxVuQA