### PR TITLE
Remove notification delay configuration from updates settings

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -58,7 +58,6 @@ export const config = new Store<Config>({
     "notifications.times": [],
     "updates.autoCheck": true,
     "updates.showNotifications": true,
-    "updates.notificationDelay": "next-day",
     "blocker.enabled": true,
     "blocker.ads": true,
     "blocker.tracking": true,
@@ -302,6 +301,13 @@ export const config = new Store<Config>({
       if (store.has("resetConfig")) {
         // @ts-expect-error
         store.delete("resetConfig");
+      }
+    },
+    ">3.45.0": (store) => {
+      // @ts-expect-error: `updates.notificationDelay` has been removed
+      if (store.has("updates.notificationDelay")) {
+        // @ts-expect-error
+        store.delete("updates.notificationDelay");
       }
     },
   },

--- a/packages/app/updater.ts
+++ b/packages/app/updater.ts
@@ -1,6 +1,4 @@
 import { is } from "@electron-toolkit/utils";
-import { ms } from "@meru/shared/ms";
-import type { UpdateDownloadedEvent } from "electron-updater";
 import { autoUpdater } from "electron-updater";
 import { config } from "@/config";
 import { ipc } from "./ipc";
@@ -8,44 +6,17 @@ import { log } from "./lib/log";
 import { main } from "./main";
 import { appState } from "./state";
 
-const URGENT_MARKERS = ["<!-- urgent -->", "[urgent]"];
-
-const NOTIFICATION_DELAY_MS = {
-  immediate: 0,
-  "few-hours": ms("4h"),
-  "next-day": ms("1d"),
-} as const;
-
-type ReleaseNotes = UpdateDownloadedEvent["releaseNotes"];
-
-function flattenReleaseNotes(releaseNotes: ReleaseNotes) {
-  if (!releaseNotes) {
-    return "";
-  }
-
-  if (typeof releaseNotes === "string") {
-    return releaseNotes;
-  }
-
-  return releaseNotes.map((entry) => entry.note ?? "").join("\n");
-}
-
-function isUrgentRelease(releaseNotes: ReleaseNotes) {
-  const text = flattenReleaseNotes(releaseNotes).toLowerCase();
-
-  return URGENT_MARKERS.some((marker) => text.includes(marker));
-}
-
 class AppUpdater {
-  private pendingVersion: string | null = null;
-  private notifyTimer: NodeJS.Timeout | null = null;
-
   init() {
     autoUpdater.logger = log;
 
     if (config.get("updates.showNotifications")) {
       autoUpdater.on("update-downloaded", (updateInfo) => {
-        this.handleUpdateDownloaded(updateInfo);
+        ipc.renderer.send(
+          main.window.webContents,
+          "appUpdater.updateAvailable",
+          `v${updateInfo.version}`,
+        );
       });
     }
 
@@ -77,45 +48,6 @@ class AppUpdater {
     appState.isQuittingApp = true;
 
     autoUpdater.quitAndInstall();
-  }
-
-  private handleUpdateDownloaded(updateInfo: UpdateDownloadedEvent) {
-    const delayMs = NOTIFICATION_DELAY_MS[config.get("updates.notificationDelay")];
-
-    if (delayMs === 0 || isUrgentRelease(updateInfo.releaseNotes)) {
-      this.clearPendingNotification();
-      this.notifyRenderer(updateInfo.version);
-
-      return;
-    }
-
-    this.clearPendingNotification();
-
-    this.pendingVersion = updateInfo.version;
-
-    this.notifyTimer = setTimeout(() => {
-      const version = this.pendingVersion;
-
-      this.notifyTimer = null;
-      this.pendingVersion = null;
-
-      if (version) {
-        this.notifyRenderer(version);
-      }
-    }, delayMs);
-  }
-
-  private clearPendingNotification() {
-    if (this.notifyTimer) {
-      clearTimeout(this.notifyTimer);
-      this.notifyTimer = null;
-    }
-
-    this.pendingVersion = null;
-  }
-
-  private notifyRenderer(version: string) {
-    ipc.renderer.send(main.window.webContents, "appUpdater.updateAvailable", `v${version}`);
   }
 }
 

--- a/packages/renderer-main/routes/settings/updates.tsx
+++ b/packages/renderer-main/routes/settings/updates.tsx
@@ -1,35 +1,8 @@
-import {
-  Field,
-  FieldContent,
-  FieldDescription,
-  FieldGroup,
-  FieldLabel,
-} from "@meru/ui/components/field";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@meru/ui/components/select";
-import { useConfig, useConfigMutation } from "@meru/shared/renderer/react-query";
+import { FieldGroup } from "@meru/ui/components/field";
 import { ConfigSwitchField } from "@/components/config-switch-field";
 import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
 
-const notificationDelayItems = [
-  { value: "next-day", label: "Next day (recommended)" },
-  { value: "few-hours", label: "After a few hours" },
-  { value: "immediate", label: "Immediately" },
-];
-
 export function UpdatesSettings() {
-  const { config } = useConfig();
-  const configMutation = useConfigMutation();
-
-  if (!config) {
-    return;
-  }
-
   return (
     <Settings>
       <SettingsHeader>
@@ -48,37 +21,6 @@ export function UpdatesSettings() {
             description="Receive notifications when updates are available."
             configKey="updates.showNotifications"
           />
-          <Field>
-            <FieldContent>
-              <FieldLabel>Notification Delay</FieldLabel>
-              <FieldDescription>
-                Batch rapid back-to-back releases into a single prompt. Urgent updates always notify
-                immediately.
-              </FieldDescription>
-            </FieldContent>
-            <Select
-              items={notificationDelayItems}
-              value={config["updates.notificationDelay"]}
-              onValueChange={(value) => {
-                if (value) {
-                  configMutation.mutate({
-                    "updates.notificationDelay": value,
-                  });
-                }
-              }}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Select when to notify" />
-              </SelectTrigger>
-              <SelectContent>
-                {notificationDelayItems.map(({ value, label }) => (
-                  <SelectItem key={value} value={value}>
-                    {label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </Field>
         </FieldGroup>
       </SettingsContent>
     </Settings>

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -123,7 +123,6 @@ export type Config = {
   "notifications.times": NotificationTime[];
   "updates.autoCheck": boolean;
   "updates.showNotifications": boolean;
-  "updates.notificationDelay": "immediate" | "few-hours" | "next-day";
   "blocker.enabled": boolean;
   "blocker.ads": boolean;
   "blocker.tracking": boolean;


### PR DESCRIPTION
## Summary
This PR removes the notification delay feature from the update notification system, simplifying the update notification logic to always notify immediately when an update is available.

## Key Changes
- **Removed notification delay logic** from `packages/app/updater.ts`:
  - Deleted `NOTIFICATION_DELAY_MS` configuration object
  - Removed `isUrgentRelease()` and `flattenReleaseNotes()` helper functions
  - Removed `handleUpdateDownloaded()`, `clearPendingNotification()`, and `notifyRenderer()` methods
  - Simplified update-downloaded handler to immediately send notification via IPC
  - Removed instance variables `pendingVersion` and `notifyTimer`

- **Removed UI controls** from `packages/renderer-main/routes/settings/updates.tsx`:
  - Deleted the "Notification Delay" select field and its configuration
  - Removed related imports and state management code
  - Kept only the "Show Notifications" toggle

- **Updated configuration schema** in `packages/shared/types.ts`:
  - Removed `"updates.notificationDelay"` type definition from Config

- **Updated default config** in `packages/app/config.ts`:
  - Removed `"updates.notificationDelay": "next-day"` from defaults
  - Added migration for version >3.45.0 to clean up the setting from existing user configs

## Implementation Details
The update notification system now operates in a single mode: when an update is downloaded and notifications are enabled, it immediately notifies the renderer without any delay or urgency-based logic. This reduces complexity while maintaining the core functionality of alerting users to available updates.

https://claude.ai/code/session_017K2CRC6vh3WfisvKkTm32K