### PR TITLE
fix titlebar overlay update crash on macOS

### DIFF
--- a/packages/app/main.ts
+++ b/packages/app/main.ts
@@ -57,6 +57,10 @@ class Main {
   }
 
   updateTitlebarOverlay() {
+    if (platform.isMacOS) {
+      return;
+    }
+
     const { titleBarOverlay } = getTitleBarOptions();
 
     if (typeof titleBarOverlay === "boolean") {


### PR DESCRIPTION
setTitleBarOverlay only exists on Windows and Linux, so the nativeTheme
"updated" handler was throwing when the user toggled their system theme
on macOS.